### PR TITLE
Bump Pygments requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for building PEPs with Sphinx
-Pygments >= 2.9.0
+Pygments >= 2.19.0
 # Sphinx 6.1.0 broke copying images in parallel builds; fixed in 6.1.2
 # See https://github.com/sphinx-doc/sphinx/pull/11100
 Sphinx >= 5.1.1, != 6.1.0, != 6.1.1, < 8.1.0


### PR DESCRIPTION
Not sure if we should do that as part of the PEP submission, but we are using lexers available since 2.19.0, as @konstin noticed.