### PR TITLE
Clarify how variants.json is presented on an index

### DIFF
--- a/peps/pep-0815.rst
+++ b/peps/pep-0815.rst
@@ -1536,8 +1536,8 @@ file, hosted and served by the package index. The ``{name}`` and
 normalized according to the same rules as wheel files, as found in the
 :ref:`packaging:wheel-file-name-spec` of the Binary Distribution Format
 specification. The link to this file must be present on all index pages
-where the variant wheels are linked. It is presented in the same format
-as source distributions and wheels in the index, including an (optional)
+where the variant wheels are linked. It is presented in the same simple repository format
+as source distribution and wheel links in the index, including an (optional)
 hash.
 
 This file uses the same structure as ``variant.json`` described above,

--- a/peps/pep-0815.rst
+++ b/peps/pep-0815.rst
@@ -1535,8 +1535,10 @@ file, hosted and served by the package index. The ``{name}`` and
 ``{version}`` placeholders correspond to the package name and version,
 normalized according to the same rules as wheel files, as found in the
 :ref:`packaging:wheel-file-name-spec` of the Binary Distribution Format
-specification.  The link to this file must be present on all index pages
-where the variant wheels are linked.
+specification. The link to this file must be present on all index pages
+where the variant wheels are linked. It is presented in the same format
+as source distributions and wheels in the index, including an (optional)
+hash.
 
 This file uses the same structure as ``variant.json`` described above,
 except that the variants object must list all variants available on the

--- a/peps/pep-0815.rst
+++ b/peps/pep-0815.rst
@@ -1536,9 +1536,9 @@ file, hosted and served by the package index. The ``{name}`` and
 normalized according to the same rules as wheel files, as found in the
 :ref:`packaging:wheel-file-name-spec` of the Binary Distribution Format
 specification. The link to this file must be present on all index pages
-where the variant wheels are linked. It is presented in the same simple repository format
-as source distribution and wheel links in the index, including an (optional)
-hash.
+where the variant wheels are linked. It is presented in the same simple
+repository format as source distribution and wheel links in the index,
+including an (optional) hash.
 
 This file uses the same structure as ``variant.json`` described above,
 except that the variants object must list all variants available on the


### PR DESCRIPTION
Following up to a comment on the PEP.

I misclicked and accidentally deleted the comment instead of my duplicate reply (and it deleted my reply with it). Apparently this can't be undone (https://github.com/orgs/community/discussions/69275#discussioncomment-7193616) - Sorry! Since it's still present in my IDE here's the comment:

> This definitely needs to be clarified. We should specify a data-dist-info-variants marker attribute to be added to the a tag linking to the variants file for the HTML encoding containing it's hash. We should introduce a new top-level [dist-info]-variants key in the JSON simple API project detail dictionary.