### PR TITLE
Rationale/spec improvements

### DIFF
--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -769,15 +769,16 @@ Overview
 
 Wheel variants introduce a more fine-grained specification of built
 wheel characteristics beyond what existing wheel tags provide.
-Individual wheels carry a human-readable label defined at build time,
-and are characterized by sets of `variant properties`_ that are
-organized into a hierarchical structure of namespaces, features and
-feature values. When evaluating wheels to install, the installer
-determines whether variant properties of a given wheel are compatible
-with the system, and perform `variant ordering`_ based on the priority
-of the compatible variant properties. This is done in addition to
-determining the compatibility. The ordering by variant properties takes
-precedence over ordering by tags.
+Individual wheels carry a human-readable label defined at build time, as
+described in `modified wheel filename`_, and are characterizing using
+`variant property system`_. The properties are organized into a
+hierarchical structure of namespaces, features and feature values. When
+evaluating wheels to install, the installer determines whether variant
+properties of a given wheel are compatible with the system, and perform
+variant ordering based on the priority of the compatible variant
+properties. This is done in addition to determining the compatibility.
+The ordering by variant properties takes precedence over ordering by
+tags.
 
 Every variant namespace is governed by a variant provider. There are two
 kinds of variant providers: install-time providers and ahead-of-time
@@ -787,7 +788,7 @@ their preference order. For AoT providers, this data is static and
 embedded in the wheel; it can be either provided directly by the
 wheel maintainer or queried at wheel build time from an AoT plugin. Both
 kinds of plugins are usually implemented as Python packages which
-implement the `provider plugin API`_, but they may also be vendored or
+implement the provider plugin API, but they may also be vendored or
 reimplemented by installers to improve security, as outlined in TODO.
 
 Modified wheel filename
@@ -840,8 +841,8 @@ and `uv
 <https://github.com/astral-sh/uv/blob/f6a9b55eb73be4f1fb9831362a192cdd8312ab96/crates/uv-distribution-filename/src/wheel.rs#L182-L299>`__.
 
 
-Variant properties system
--------------------------
+Variant property system
+-----------------------
 
 Variant properties serve the purpose of expressing the characteristics
 of the variant. Unlike platform compatibility tags, they are stored in

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1050,6 +1050,32 @@ implement explicit variant metadata support on the package index
 software.
 
 
+ABI dependency variant provider
+-------------------------------
+
+Some packages provide extension modules exposing Application Binary
+Interface (ABI) that is not compatible across wide ranges of versions.
+The packages using this interface need to pin their wheels to the
+version used at build time. If ABI changes frequently, the pins are very
+narrow and users face problems if they need to install two packages that
+may happen to pin to different versions of the same dependency.
+Providing variants built against different dependency versions can
+increase the chances of resolver being able to find a dependency version
+that is compatible with all the packages being installed.
+
+Unfortunately, such a variant provider cannot be implemented within the
+plugin API defined by the specification. Given that a robust
+implementation would need to interface with the dependency resolver,
+rather than attempt to extend the API to cover this use case and add
+significant complexity as a result, the specification reserves
+``abi_dependency`` as a special variant namespace that can be
+implemented by installers wishing the provide this feature.
+
+Given the complexity of the problem, this extension is made entirely
+optional. This implies that any packages using it need to provide
+regular wheels as well.
+
+
 Example use cases
 -----------------
 
@@ -1998,10 +2024,10 @@ particular, packages published to PyPI MUST NOT rely on plugins that
 need to be installed from other indexes.
 
 Except for namespaces reserved as part of this PEP, installable Python
-packages MUST be provided for plugins. However, as noted in
-`providers`_, these plugins can also be reimplemented by tools needing
-them. In the latter case, the resulting reimplementation does not need
-to follow the API defined in this section.
+packages MUST be provided for plugins. However, as noted in the
+`Providers`_ section, these plugins can also be reimplemented by tools
+needing them. In the latter case, the resulting reimplementation does
+not need to follow the API defined in this section.
 
 A plugin implemented as Python package exposes two kinds of objects at a
 specified API endpoint:

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1378,11 +1378,10 @@ to enable optional providers.
 
 Providers can also be made conditional to
 :ref:`dependency-specifiers-environment-markers`. If that is the case,
-the installer SHOULD check the markers against the environment to which
-wheels are going to be installed. It SHOULD NOT use any providers whose
-markers do not match, and instead assume that its properties are
-incompatible. However, providers themselves MUST return no compatible
-properties, if queried on such a system.
+the installer MUST check the markers against the environment to which
+wheels are going to be installed. It MUST NOT use any providers whose
+markers do not match, and instead assume that their properties are
+incompatible.
 
 All the tools that need to query variant providers and are run in a
 security-sensitive context, MUST NOT install or run code from any

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -775,7 +775,7 @@ described in `modified wheel filename`_, and are characterizing using
 hierarchical structure of namespaces, features and feature values. When
 evaluating wheels to install, the installer determines whether variant
 properties of a given wheel are compatible with the system, and perform
-variant ordering based on the priority of the compatible variant
+`variant ordering`_ based on the priority of the compatible variant
 properties. This is done in addition to determining the compatibility.
 The ordering by variant properties takes precedence over ordering by
 tags.
@@ -789,17 +789,21 @@ embedded in the wheel; it can be either provided directly by the
 wheel maintainer or queried at wheel build time from an AoT plugin.
 
 Both kinds of plugins are usually implemented as Python packages which
-implement the provider plugin API, but they may also be vendored or
+implement the `provider plugin API`_, but they may also be vendored or
 reimplemented by installers to improve security, as outlined in
-`Providers`_.
-
-Plugin packages may be installed in isolated or non-isolated
-environments. In particular, all plugins may be returned by the
-``get_requires_for_build_wheel()`` hook of a :pep:`517` backend, and
+`Providers`_. Plugin packages may be installed in isolated or
+non-isolated environments. In particular, all plugins may be returned by
+the ``get_requires_for_build_wheel()`` hook of a :pep:`517` backend, and
 therefore installed along with other build dependencies. For this
 reason, it is important that plugin packages do not narrowly pin
 dependencies, as that could prevent different packages from being
 installed simultaneously in the same environment.
+
+Metadata governing variant support is defined in ``pyproject.toml``
+file, and it is copied into ``variant.json`` file in wheels, as explored
+in `metadata in source tree and wheels`_. Additionally, `variant
+environment markers`_ can be used to define dependencies specific to a
+subset of variants.
 
 
 Modified wheel filename

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1359,11 +1359,11 @@ Examples:
 Providers
 ---------
 
-When installing variant wheels, installers SHOULD verify whether a given
-wheel's properties are compatible with the system in question by
-querying the variant providers, though they MAY provide an option to
-omit the verification. Having to select between multiple variant wheels,
-they MUST perform said verification and `variant ordering`_.
+When installing or resolving variant wheels, installers SHOULD query the
+variant provider to verify whether a given wheel's properties are
+compatible with the system and to select the best variant through
+`variant ordering`_. However, they MAY provide an option to omit the
+verification and install a specified variant explicitly.
 
 Providers can be marked as install-time or ahead-of-time. For
 install-time providers, installers MUST use the provider package or an

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -2310,11 +2310,12 @@ wheels or not, :pep:`517` and :pep:`660` hooks MUST build non-variant
 wheels by default. Build backends MAY provide ways to request variant
 builds. This specification does not define any specific configuration.
 
-When building variant wheels, build backends SHOULD query providers to
-determine whether variant properties requested by the user are valid.
-They MUST refuse to build variant wheels with invalid metadata, and
-SHOULD refuse to build wheels with properties that are not considered
-valid according to their providers.
+When building variant wheels, build backends MUST verify variant
+metadata for correctness, and they MUST NOT emit wheels with
+nonconformant ``variant.json`` files. They SHOULD also query providers
+to determine whether variant properties requested by the user are valid,
+though they MAY permit skipping this verification and therefore emitting
+variant wheels with potentially unknown properties.
 
 
 Variant environment markers

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -747,6 +747,110 @@ The Wheel Variant PEP introduces four key components:
    dependencies that are applicable to a subset of variants only.
 
 
+Wheel variant glossary
+----------------------
+
+Variant Wheels
+    Wheels that share the same distribution name, version, build number,
+    and platform compatibility tags, but are distinctly identified by an
+    arbitrary set of variant properties.
+
+Variant Namespace
+    An identifier used to group related features provided by a single
+    provider (e.g., ``nvidia``, ``x86_64``, ``arm``, etc.).
+
+Variant Feature
+    A specific characteristic (key) within a namespace (e.g.,
+    ``version``, ``avx512_bf16``, etc.) that can have one or more
+    values.
+
+Variant Property
+    A 3-tuple (``namespace :: feature-name :: feature-value``)
+    describing a single specific feature and its value. If a feature has
+    multiple values, each is represented by a separate property.
+
+Variant Label
+    A string (up to 16 characters) added to the wheel filename to
+    uniquely identify variants.
+
+Null Variant
+    A special variant with zero variant properties and the reserved
+    label ``null``. Always considered supported but has the lowest
+    priority among wheel variants, while being preferably chosen over
+    non-variant wheels.
+
+Variant Provider
+    A provider of supported and valid variant properties for a specific
+    namespace, usually in the form of a Python package that implements
+    system detection.
+
+Install-time Provider
+    A provider implemented as a plugin that can be queried during wheel
+    installation.
+
+Ahead-of-Time Provider
+    A provider that features a static list of supported properties which
+    is then embedded in the wheel metadata. Such a list can either be
+    embedded in ``pyproject.toml`` or provided by a plugin queried at
+    build time.
+
+
+Overview
+--------
+
+Wheel variants introduce a more fine-grained specification of built
+wheel characteristics beyond what existing wheel tags provide.
+Individual wheels are characterized by sets of `variant properties`_
+that are organized into a hierarchical structure of namespaces, features
+and feature values. When evaluating wheels to install, the installer
+MUST determine whether variant properties are compatible with the
+system, and perform `variant ordering`_ based on the priority of the
+compatible variant properties. This is done in addition to determining
+the compatibility and ordering through tags. The ordering by variant
+properties takes precedence over ordering by tags. Null variants
+(variants with no variant properties) are preferred over non-variant
+wheels with the same tags.
+
+Every variant namespace is governed by a variant provider. There are two
+kinds of variant providers: install-time providers and ahead-of-time
+(AoT) providers. Install-time providers require plugins that are queried
+while installing wheels to determine the set of supported properties and
+their preference order. For AoT providers, this data is static and
+embedded in the wheel; it can be either provided directly by the
+wheel maintainer or queried at wheel build time from an AoT plugin. Both
+kinds of plugins are usually implemented as Python packages which
+implement the `provider plugin API`_.
+
+Installers, as well as other tools that need to verify variant wheel
+compatibility and are run in security-sensitive context, MUST NOT
+install or run code from any untrusted package for variant resolution
+without explicit user opt-in. Provider packages SHOULD take measures to
+guard against supply chain attacks, for example by vendoring all
+dependencies. Pinning dependencies is discouraged to comply with
+:pep:`517`
+build process, as provider plugins MAY be needed at build time and
+dependencies pinned to different versions could prevent different
+plugins from being installed simultaneously in the same environment.
+
+It is RECOMMENDED that these tools vendor, reimplement or lock the most
+commonly used plugins to specific wheels after verifying
+their trustworthiness, to enable the ability to securely install variant
+wheels out-of-the-box. To reduce the maintenance costs, repositories of
+such vetted plugins could be maintained collaboratively and shared
+between different tools.
+
+For plugins and their dependencies not in such a pre-approved list,
+a trust-on-first-use mechanism for every version is RECOMMENDED. In
+interactive sessions, the tool can explicitly ask the user for approval.
+In non-interactive sessions, the approval can be given using
+command-line interface options. It is important that the user is
+informed of the risk before giving such an approval.
+
+For a consistent experience between tools, variant wheels SHOULD be
+supported by default. Tools MAY provide an option to only use
+non-variant wheels. For scenarios requiring more control, providers can
+be marked as optional and then must be explicitly enabled by the user
+for the wheels to become available for installation.
 Modified wheel filename
 -----------------------
 
@@ -1124,113 +1228,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted as described in :rfc:`2119`.
 
 
-Wheel variant glossary
-----------------------
-
-This section focuses specifically on the vocabulary used by the proposed
-"Wheel Variant" standard:
-
-Variant Wheels
-    Wheels that share the same distribution name, version, build number,
-    and platform compatibility tags, but are distinctly identified by an
-    arbitrary set of variant properties.
-
-Variant Namespace
-    An identifier used to group related features provided by a single
-    provider (e.g., ``nvidia``, ``x86_64``, ``arm``, etc.).
-
-Variant Feature
-    A specific characteristic (key) within a namespace (e.g.,
-    ``version``, ``avx512_bf16``, etc.) that can have one or more
-    values.
-
-Variant Property
-    A 3-tuple (``namespace :: feature-name :: feature-value``)
-    describing a single specific feature and its value. If a feature has
-    multiple values, each is represented by a separate property.
-
-Variant Label
-    A string (up to 16 characters) added to the wheel filename to
-    uniquely identify variants.
-
-Null Variant
-    A special variant with zero variant properties and the reserved
-    label ``null``. Always considered supported but has the lowest
-    priority among wheel variants, while being preferably chosen over
-    non-variant wheels.
-
-Variant Provider
-    A provider of supported and valid variant properties for a specific
-    namespace, usually in the form of a Python package that implements
-    system detection.
-
-Install-time Provider
-    A provider implemented as a plugin that can be queried during wheel
-    installation.
-
-Ahead-of-Time Provider
-    A provider that features a static list of supported properties which
-    is then embedded in the wheel metadata. Such a list can either be
-    embedded in ``pyproject.toml`` or provided by a plugin queried at
-    build time.
-
-
-Overview
---------
-
-Wheel variants introduce a more fine-grained specification of built
-wheel characteristics beyond what existing wheel tags provide.
-Individual wheels are characterized by sets of `variant properties`_
-that are organized into a hierarchical structure of namespaces, features
-and feature values. When evaluating wheels to install, the installer
-MUST determine whether variant properties are compatible with the
-system, and perform `variant ordering`_ based on the priority of the
-compatible variant properties. This is done in addition to determining
-the compatibility and ordering through tags. The ordering by variant
-properties takes precedence over ordering by tags. Null variants
-(variants with no variant properties) are preferred over non-variant
-wheels with the same tags.
-
-Every variant namespace is governed by a variant provider. There are two
-kinds of variant providers: install-time providers and ahead-of-time
-(AoT) providers. Install-time providers require plugins that are queried
-while installing wheels to determine the set of supported properties and
-their preference order. For AoT providers, this data is static and
-embedded in the wheel; it can be either provided directly by the
-wheel maintainer or queried at wheel build time from an AoT plugin. Both
-kinds of plugins are usually implemented as Python packages which
-implement the `provider plugin API`_.
-
-Installers, as well as other tools that need to verify variant wheel
-compatibility and are run in security-sensitive context, MUST NOT
-install or run code from any untrusted package for variant resolution
-without explicit user opt-in. Provider packages SHOULD take measures to
-guard against supply chain attacks, for example by vendoring all
-dependencies. Pinning dependencies is discouraged to comply with
-:pep:`517`
-build process, as provider plugins MAY be needed at build time and
-dependencies pinned to different versions could prevent different
-plugins from being installed simultaneously in the same environment.
-
-It is RECOMMENDED that these tools vendor, reimplement or lock the most
-commonly used plugins to specific wheels after verifying
-their trustworthiness, to enable the ability to securely install variant
-wheels out-of-the-box. To reduce the maintenance costs, repositories of
-such vetted plugins could be maintained collaboratively and shared
-between different tools.
-
-For plugins and their dependencies not in such a pre-approved list,
-a trust-on-first-use mechanism for every version is RECOMMENDED. In
-interactive sessions, the tool can explicitly ask the user for approval.
-In non-interactive sessions, the approval can be given using
-command-line interface options. It is important that the user is
-informed of the risk before giving such an approval.
-
-For a consistent experience between tools, variant wheels SHOULD be
-supported by default. Tools MAY provide an option to only use
-non-variant wheels. For scenarios requiring more control, providers can
-be marked as optional and then must be explicitly enabled by the user
-for the wheels to become available for installation.
 
 
 Extended wheel filename

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -975,12 +975,13 @@ or to provide debug builds of packages. Since they do not require
 running code external to the installer, they do not pose the problems
 faced by install-time providers, and can be used more liberally.
 
-For user convenience and better consistency across different packages,
 AoT providers are permitted to feature plugin packages. If that is the
 case, these packages are only used when building wheels, and their
 output is used to fill in the static metadata used at install time.
-Otherwise, the package maintainer needs to include this metadata
-straight in ``pyproject.toml`` file.
+This way, it is easier to use consistent property names and values
+across multiple packages. Otherwise, the package maintainer needs to
+include the supported properties directly in the ``pyproject.toml``
+file.
 
 When implemented as Python packages, both kinds of provider plugins
 roughly expose the same API. However, an AoT provider must always
@@ -993,9 +994,10 @@ providers, but not the other way around.
 Plugin stability and versioning
 -------------------------------
 
-Given that calling provider plugins may be necessary while installing
-variant wheels published in the past, it is important that provider
-plugin behavior remain stable within their lifetime. Ideally, no
+As the specification introduces the potential necessity of installing
+and running provider packages to install wheels, it is recommended that
+these packages remain functioning correctly for the variant wheels
+published in the past, including very old package versions. Ideally, no
 properties previously supported should ever be removed.
 
 If a breaking change needs to be performed, it is recommended to either

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1085,10 +1085,10 @@ PyTorch CPU/GPU variants
 ''''''''''''''''''''''''
 
 As of October 2025, `PyTorch
-<https://pytorch.org/get-started/locally/>`__ publishes builds a total
-of seven variants for every release: a CPU-only variant, three CUDA
-variants with different minimal CUDA runtime versions and supported
-GPUs, two ROCm variants and a Linux XPU variant.
+<https://pytorch.org/get-started/locally/>`__ publishes a total of seven
+variants for every release: a CPU-only variant, three CUDA variants with
+different minimal CUDA runtime versions and supported GPUs, two ROCm
+variants and a Linux XPU variant.
 
 This setup could be improved using GPU/XPU plugins that query the
 installed runtime version and installed GPUs/XPUs to filter out the

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1337,6 +1337,25 @@ querying the variant providers, though they MAY provide an option to
 omit the verification. Having to select between multiple variant wheels,
 they MUST perform said verification and `variant ordering`_.
 
+Providers can be marked as install-time or ahead-of-time. For
+install-time providers, installers MUST use the provider package or an
+equivalent reimplementation to query variant property compatibility. For
+ahead-of-time providers, they MUST use the static metadata embedded in
+the wheel instead.
+
+Providers can be marked as optional. If a provider is marked optional,
+then the installer MUST NOT query said provider by default, and instead
+assume that its properties are incompatible. It SHOULD provide an option
+to enable optional providers.
+
+Providers can also be made conditional to
+:ref:`dependency-specifiers-environment-markers`. If that is the case,
+the installer SHOULD check the markers against the environment to which
+wheels are going to be installed. It SHOULD NOT use any providers whose
+markers do not match, and instead assume that its properties are
+incompatible. However, providers themselves MUST return no compatible
+properties, if queried on such a system.
+
 All the tools that need to query variant providers and are run in a
 security-sensitive context, MUST NOT install or run code from any
 untrusted package for variant resolution without explicit user opt-in.
@@ -1437,11 +1456,14 @@ declared in ``pyproject.toml`` for every variant namespace supported by
 the package. It MUST be copied to ``variant.json`` as-is, including
 the data for providers that are not used in the particular wheel.
 
+The use of provider information is described in the `Providers`_ and
+`Provider plugin API`_ sections.
+
 A provider information dictionary MAY contain the following keys:
 
 - ``enable-if: str``: An :ref:`environment marker
   <dependency-specifiers-environment-markers>` defining when the plugin
-  SHOULD be used. If the environment marker does not match the running
+  should be used. If the environment marker does not match the running
   environment, the provider will be disabled and the variants using its
   properties will be deemed incompatible. If not provided, the plugin
   will be used in all environments.
@@ -1955,9 +1977,7 @@ Every provider plugin MUST operate within a single namespace. This
 namespace is used as a unique key for all plugin-related operations. All
 the properties defined by the plugin are bound within the plugin's
 namespace, and the plugin defines all the valid feature names and values
-within that namespace. When building wheels, the tools SHOULD query the
-respective provider plugins to verify that the properties specified by
-the user are valid.
+within that namespace.
 
 Provider plugin authors SHOULD choose namespaces that can be clearly
 associated with the project they represent, and avoid namespaces that
@@ -1977,8 +1997,14 @@ published in the same indexes that the packages using them. In
 particular, packages published to PyPI MUST NOT rely on plugins that
 need to be installed from other indexes.
 
-Plugins are implemented as Python packages. They need to expose two
-kinds of Python objects at a specified API endpoint:
+Except for namespaces reserved as part of this PEP, installable Python
+packages MUST be provided for plugins. However, as noted in
+`providers`_, these plugins can also be reimplemented by tools needing
+them. In the latter case, the resulting reimplementation does not need
+to follow the API defined in this section.
+
+A plugin implemented as Python package exposes two kinds of objects at a
+specified API endpoint:
 
 a. attributes that return a specific value after being accessed via:
 
@@ -1992,9 +2018,9 @@ b. callables that are called via:
 
        {API endpoint}.{callable name}({arguments}...)
 
-These can be
-implemented either as modules, or classes with class methods or static
-methods. The specifics are provided in the subsequent sections.
+These can be implemented either as modules, or classes with class
+methods or static methods. The specifics are provided in the subsequent
+sections.
 
 
 API endpoint
@@ -2257,6 +2283,12 @@ As a build backend can't determine whether the frontend supports variant
 wheels or not, :pep:`517` and :pep:`660` hooks MUST build non-variant
 wheels by default. Build backends MAY provide ways to request variant
 builds. This specification does not define any specific configuration.
+
+When building variant wheels, build backends SHOULD query providers to
+determine whether variant properties requested by the user are valid.
+They MUST refuse to build variant wheels with invalid metadata, and
+SHOULD refuse to build wheels with properties that are not considered
+valid according to their providers.
 
 
 Variant environment markers

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1394,11 +1394,10 @@ different versions could prevent different plugins from being installed
 simultaneously in the same environment.
 
 It is RECOMMENDED that said tools vendor, reimplement or lock the most
-commonly used plugins to specific wheels after verifying
-their trustworthiness, to enable the ability to securely install variant
-wheels out-of-the-box. To reduce the maintenance costs, repositories of
-such vetted plugins could be maintained collaboratively and shared
-between different tools.
+commonly used plugins to specific wheels, to enable the ability to
+securely install variant wheels out-of-the-box. To reduce the
+maintenance costs, repositories of such vetted plugins could be
+maintained collaboratively and shared between different tools.
 
 For plugins and their dependencies that are neither reimplemented,
 vendored nor otherwise vetted, a trust-on-first-use mechanism for every

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1386,11 +1386,11 @@ incompatible.
 All the tools that need to query variant providers and are run in a
 security-sensitive context, MUST NOT install or run code from any
 untrusted package for variant resolution without explicit user opt-in.
-Provider packages SHOULD take measures to guard against supply chain
-attacks, for example by vendoring all dependencies. Pinning dependencies
-is discouraged to comply with :pep:`517` build process, as provider
-plugins may be needed at build time and dependencies pinned to different
-versions could prevent different plugins from being installed
+Install-time provider packages SHOULD take measures to guard against
+supply chain attacks, for example by vendoring all dependencies. Pinning
+dependencies is discouraged to comply with :pep:`517` build process, as
+provider plugins may be needed at build time and dependencies pinned to
+different versions could prevent different plugins from being installed
 simultaneously in the same environment.
 
 It is RECOMMENDED that said tools vendor, reimplement or lock the most

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1493,10 +1493,7 @@ A provider information dictionary MAY contain the following keys:
 
 - ``enable-if: str``: An :ref:`environment marker
   <dependency-specifiers-environment-markers>` defining when the plugin
-  should be used. If the environment marker does not match the running
-  environment, the provider will be disabled and the variants using its
-  properties will be deemed incompatible. If not provided, the plugin
-  will be used in all environments.
+  should be used.
 
 - ``install-time: bool``: Whether this is an install-time provider.
   Defaults to ``true``. ``false`` means that it is an AoT provider
@@ -1504,10 +1501,7 @@ A provider information dictionary MAY contain the following keys:
 
 - ``optional: bool``: Whether the provider is optional. Defaults
   to ``false``. If it is ``true``, the provider is
-  considered optional and SHOULD NOT be used unless the user opts in to
-  it, effectively rendering the variants using its properties
-  incompatible. If it is ``false``, the provider is considered
-  obligatory.
+  considered optional.
 
 - ``plugin-api: str``: The API endpoint for the plugin. If it is
   specified, it MUST be an object reference as explained in the `API

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -912,7 +912,7 @@ Null variant
 A null variant is a variant wheel with no properties, but distinct
 from non-variant wheels in having the ``null`` variant label and variant
 metadata. During the transition period, it provides the possibility of
-providing a distinct fallbacks for systems that do not support any of
+providing a distinct fallback for systems that do not support any of
 the variants provided, and for systems that do support variant wheels at
 all.
 
@@ -945,7 +945,7 @@ Install-time and Ahead-of-Time providers
 ----------------------------------------
 
 The variant wheel metadata specifies what providers are used for its
-properties. Providers serve twofold purpose:
+properties. Providers serve a twofold purpose:
 
 a. at install time: determining which variant wheels are compatible with
    the user's system, and which of them constitutes the best choice, and
@@ -957,7 +957,7 @@ The specification proposes two kinds of providers: install-time
 providers and Ahead-of-Time providers.
 
 Install-time providers are implemented either as Python packages that
-need to be installed and ran to query them, or vendored or reimplemented
+need to be installed and run to query them, or vendored or reimplemented
 in the tools. They are used when user systems need to be queried to
 determine wheel compatibility, for example for variants utilizing GPUs
 or requiring CPU instruction sets beyond what platform tags provide.
@@ -984,10 +984,10 @@ include the supported properties directly in the ``pyproject.toml``
 file.
 
 When implemented as Python packages, both kinds of provider plugins
-roughly expose the same API. However, an AoT provider must always
+expose roughly the same API. However, an AoT provider must always
 consider all valid variant properties supported, and it must always
 return the same ordered list of supported properties irrespective of the
-user system. All AoT providers can be technically used as install-time
+user system. All AoT providers can technically be used as install-time
 providers, but not the other way around.
 
 
@@ -1024,7 +1024,7 @@ the installer's implementation.
 Metadata in project tree and wheels
 -----------------------------------
 
-Variants introduce a few new portions of metadata that is stored in the
+Variants introduce a few new portions of metadata that are stored in the
 project tree and in wheels. In the project tree, it is stored in the
 ``pyproject.toml`` file along with other project properties, benefiting
 from the TOML format's readability and strictness. Afterwards, it is
@@ -1034,7 +1034,7 @@ unchanged to avoid unnecessary incompatibility, and to avoid serializing
 into the inconvenient :doc:`Core Metadata
 <packaging:specifications/core-metadata>` format.
 
-The project tree-level metadata includes:
+The metadata in ``pyproject.toml`` includes:
 
 - information about variant providers that could be used by the wheels,
 - optionally, lists overriding the default property ordering,
@@ -1048,21 +1048,21 @@ When wheels are published on an index, the variant metadata from all
 wheels is combined into a single ``{name}-{version}-variants.json`` file
 that is used by clients to efficiently obtain the variant metadata
 without having to download it from individual wheels separately, or
-implement explicit variant metadata support on the package index
-software.
+implement explicit variant metadata support in an API provided by the
+package index server.
 
 
 ABI dependency variant provider
 -------------------------------
 
-Some packages provide extension modules exposing Application Binary
+Some packages provide extension modules exposing an Application Binary
 Interface (ABI) that is not compatible across wide ranges of versions.
 The packages using this interface need to pin their wheels to the
 version used at build time. If ABI changes frequently, the pins are very
 narrow and users face problems if they need to install two packages that
 may happen to pin to different versions of the same dependency.
 Providing variants built against different dependency versions can
-increase the chances of resolver being able to find a dependency version
+increase the chance of a resolver being able to find a dependency version
 that is compatible with all the packages being installed.
 
 Unfortunately, such a variant provider cannot be implemented within the

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -789,7 +789,9 @@ embedded in the wheel; it can be either provided directly by the
 wheel maintainer or queried at wheel build time from an AoT plugin. Both
 kinds of plugins are usually implemented as Python packages which
 implement the provider plugin API, but they may also be vendored or
-reimplemented by installers to improve security, as outlined in TODO.
+reimplemented by installers to improve security, as outlined in
+`Providers`_.
+
 
 Modified wheel filename
 -----------------------
@@ -1228,8 +1230,7 @@ otherwise processing it. To uphold this assumption, the proposal
 explicitly requires that untrusted provider plugin packages are never installed
 without explicit user consent.
 
-// TODO: update this
-The `Overview`_ section of the specification provides further
+The `Providers`_ section of the specification provides further
 suggestions that aim to improve both security and the user experience.
 It is expected that a limited subset of popular provider plugins will
 be either vendored by the installer, eliminating the use of packages

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -786,11 +786,20 @@ kinds of variant providers: install-time providers and ahead-of-time
 while installing wheels to determine the set of supported properties and
 their preference order. For AoT providers, this data is static and
 embedded in the wheel; it can be either provided directly by the
-wheel maintainer or queried at wheel build time from an AoT plugin. Both
-kinds of plugins are usually implemented as Python packages which
+wheel maintainer or queried at wheel build time from an AoT plugin.
+
+Both kinds of plugins are usually implemented as Python packages which
 implement the provider plugin API, but they may also be vendored or
 reimplemented by installers to improve security, as outlined in
 `Providers`_.
+
+Plugin packages may be installed in isolated or non-isolated
+environments. In particular, all plugins may be returned by the
+``get_requires_for_build_wheel()`` hook of a :pep:`517` backend, and
+therefore installed along with other build dependencies. For this
+reason, it is important that plugin packages do not narrowly pin
+dependencies, as that could prevent different packages from being
+installed simultaneously in the same environment.
 
 
 Modified wheel filename
@@ -1388,11 +1397,7 @@ All the tools that need to query variant providers and are run in a
 security-sensitive context, MUST NOT install or run code from any
 untrusted package for variant resolution without explicit user opt-in.
 Install-time provider packages SHOULD take measures to guard against
-supply chain attacks, for example by vendoring all dependencies. Pinning
-dependencies is discouraged to comply with :pep:`517` build process, as
-provider plugins may be needed at build time and dependencies pinned to
-different versions could prevent different plugins from being installed
-simultaneously in the same environment.
+supply chain attacks, for example by vendoring all dependencies.
 
 It is RECOMMENDED that said tools vendor, reimplement or lock the most
 commonly used plugins to specific wheels. For plugins and their

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1206,12 +1206,13 @@ for the wheels to become available for installation.
 Extended wheel filename
 -----------------------
 
-This PEP changes the wheel filename template originally defined by
-:pep:`427` to:
+The wheel filename template originally defined by :pep:`427` is changed
+to:
 
 .. code:: text
 
     {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}(-{variant label})?.whl
+                                                                                 +++++++++++++++++++
 
 Wheels using extensions introduced by this PEP MUST feature the variant
 label component. The label MUST adhere to the following rules:

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1395,23 +1395,17 @@ different versions could prevent different plugins from being installed
 simultaneously in the same environment.
 
 It is RECOMMENDED that said tools vendor, reimplement or lock the most
-commonly used plugins to specific wheels, to enable the ability to
-securely install variant wheels out-of-the-box. To reduce the
-maintenance costs, repositories of such vetted plugins could be
-maintained collaboratively and shared between different tools.
-
-For plugins and their dependencies that are neither reimplemented,
-vendored nor otherwise vetted, a trust-on-first-use mechanism for every
-version is RECOMMENDED. In interactive sessions, the tool can explicitly
-ask the user for approval. In non-interactive sessions, the approval
-can be given using command-line interface options. It is important that
-the user is informed of the risk before giving such an approval.
+commonly used plugins to specific wheels. For plugins and their
+dependencies that are neither reimplemented, vendored nor otherwise
+vetted, a trust-on-first-use mechanism for every version is RECOMMENDED.
+In interactive sessions, the tool can explicitly ask the user for
+approval. In non-interactive sessions, the approval can be given using
+command-line interface options. It is important that the user is
+informed of the risk before giving such an approval.
 
 For a consistent experience between tools, variant wheels SHOULD be
 supported by default. Tools MAY provide an option to only use
-non-variant wheels. For scenarios requiring more control, providers can
-be marked as optional and then must be explicitly enabled by the user
-for the wheels to become available for installation.
+non-variant wheels.
 
 
 Variant metadata

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1075,7 +1075,7 @@ implemented by installers wishing the provide this feature.
 
 Given the complexity of the problem, this extension is made entirely
 optional. This implies that any packages using it need to provide
-regular wheels as well.
+non-variant wheels as well.
 
 
 Example use cases
@@ -2493,7 +2493,7 @@ with the user's system. This is achieved by `extending wheel filename
 <#extended-wheel-filename>`__ through adding a ``-{variant label}``
 component to the end of the filename, effectively causing variant wheels
 to be rejected by common installer implementations. For backwards
-compatibility, a regular wheel can be published in addition to the
+compatibility, a non-variant wheel can be published in addition to the
 variant wheels. It will be the only wheel supported by incompatible
 installers, and the least preferred wheel for variant-compatible
 installers.
@@ -2511,7 +2511,7 @@ This is a general problem with the design of environment markers, and
 not specific to wheel variants. It is possible to work around this
 problem by partially evaluating environment markers at build time, and
 removing the markers or dependencies specific to variant wheels from the
-regular wheel.
+non-variant wheel.
 
 `Build backends`_ produce non-variant wheels to preserve backwards
 compatibility with existing frontends. Variant wheels can only be output

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -800,16 +800,15 @@ Overview
 
 Wheel variants introduce a more fine-grained specification of built
 wheel characteristics beyond what existing wheel tags provide.
-Individual wheels are characterized by sets of `variant properties`_
-that are organized into a hierarchical structure of namespaces, features
-and feature values. When evaluating wheels to install, the installer
-MUST determine whether variant properties are compatible with the
-system, and perform `variant ordering`_ based on the priority of the
-compatible variant properties. This is done in addition to determining
-the compatibility and ordering through tags. The ordering by variant
-properties takes precedence over ordering by tags. Null variants
-(variants with no variant properties) are preferred over non-variant
-wheels with the same tags.
+Individual wheels carry a human-readable label defined at build time,
+and are characterized by sets of `variant properties`_ that are
+organized into a hierarchical structure of namespaces, features and
+feature values. When evaluating wheels to install, the installer
+determines whether variant properties of a given wheel are compatible
+with the system, and perform `variant ordering`_ based on the priority
+of the compatible variant properties. This is done in addition to
+determining the compatibility. The ordering by variant properties takes
+precedence over ordering by tags.
 
 Every variant namespace is governed by a variant provider. There are two
 kinds of variant providers: install-time providers and ahead-of-time
@@ -819,38 +818,9 @@ their preference order. For AoT providers, this data is static and
 embedded in the wheel; it can be either provided directly by the
 wheel maintainer or queried at wheel build time from an AoT plugin. Both
 kinds of plugins are usually implemented as Python packages which
-implement the `provider plugin API`_.
+implement the `provider plugin API`_, but they may also be vendored or
+reimplemented by installers to improve security, as outlined in TODO.
 
-Installers, as well as other tools that need to verify variant wheel
-compatibility and are run in security-sensitive context, MUST NOT
-install or run code from any untrusted package for variant resolution
-without explicit user opt-in. Provider packages SHOULD take measures to
-guard against supply chain attacks, for example by vendoring all
-dependencies. Pinning dependencies is discouraged to comply with
-:pep:`517`
-build process, as provider plugins MAY be needed at build time and
-dependencies pinned to different versions could prevent different
-plugins from being installed simultaneously in the same environment.
-
-It is RECOMMENDED that these tools vendor, reimplement or lock the most
-commonly used plugins to specific wheels after verifying
-their trustworthiness, to enable the ability to securely install variant
-wheels out-of-the-box. To reduce the maintenance costs, repositories of
-such vetted plugins could be maintained collaboratively and shared
-between different tools.
-
-For plugins and their dependencies not in such a pre-approved list,
-a trust-on-first-use mechanism for every version is RECOMMENDED. In
-interactive sessions, the tool can explicitly ask the user for approval.
-In non-interactive sessions, the approval can be given using
-command-line interface options. It is important that the user is
-informed of the risk before giving such an approval.
-
-For a consistent experience between tools, variant wheels SHOULD be
-supported by default. Tools MAY provide an option to only use
-non-variant wheels. For scenarios requiring more control, providers can
-be marked as optional and then must be explicitly enabled by the user
-for the wheels to become available for installation.
 Modified wheel filename
 -----------------------
 
@@ -1195,6 +1165,7 @@ otherwise processing it. To uphold this assumption, the proposal
 explicitly requires that untrusted provider plugin packages are never installed
 without explicit user consent.
 
+// TODO: update this
 The `Overview`_ section of the specification provides further
 suggestions that aim to improve both security and the user experience.
 It is expected that a limited subset of popular provider plugins will
@@ -1228,6 +1199,39 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted as described in :rfc:`2119`.
 
 
+Things to include again
+-----------------------
+
+Installers, as well as other tools that need to verify variant wheel
+compatibility and are run in security-sensitive context, MUST NOT
+install or run code from any untrusted package for variant resolution
+without explicit user opt-in. Provider packages SHOULD take measures to
+guard against supply chain attacks, for example by vendoring all
+dependencies. Pinning dependencies is discouraged to comply with
+:pep:`517`
+build process, as provider plugins MAY be needed at build time and
+dependencies pinned to different versions could prevent different
+plugins from being installed simultaneously in the same environment.
+
+It is RECOMMENDED that these tools vendor, reimplement or lock the most
+commonly used plugins to specific wheels after verifying
+their trustworthiness, to enable the ability to securely install variant
+wheels out-of-the-box. To reduce the maintenance costs, repositories of
+such vetted plugins could be maintained collaboratively and shared
+between different tools.
+
+For plugins and their dependencies not in such a pre-approved list,
+a trust-on-first-use mechanism for every version is RECOMMENDED. In
+interactive sessions, the tool can explicitly ask the user for approval.
+In non-interactive sessions, the approval can be given using
+command-line interface options. It is important that the user is
+informed of the risk before giving such an approval.
+
+For a consistent experience between tools, variant wheels SHOULD be
+supported by default. Tools MAY provide an option to only use
+non-variant wheels. For scenarios requiring more control, providers can
+be marked as optional and then must be explicitly enabled by the user
+for the wheels to become available for installation.
 
 
 Extended wheel filename

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1019,6 +1019,37 @@ the external plugin when the package in question is incompatible with
 the installer's implementation.
 
 
+Metadata in project tree and wheels
+-----------------------------------
+
+Variants introduce a few new portions of metadata that is stored in the
+project tree and in wheels. In the project tree, it is stored in the
+``pyproject.toml`` file along with other project properties, benefiting
+from the TOML format's readability and strictness. Afterwards, it is
+converted into an equivalent JSON structure, and stored as a separate
+file in the ``.dist-info`` directory. The existing metadata files are
+unchanged to avoid unnecessary incompatibility, and to avoid serializing
+into the inconvenient :doc:`Core Metadata
+<packaging:specifications/core-metadata>` format.
+
+The project tree-level metadata includes:
+
+- information about variant providers that could be used by the wheels,
+- optionally, lists overriding the default property ordering,
+- static property lists for Ahead-of-Time providers that do not use
+  plugins.
+
+In wheel metadata, the above is amended by static property lists
+obtained from the plugins and variant properties for the built wheel.
+
+When wheels are published on an index, the variant metadata from all
+wheels is combined into a single ``{name}-{version}-variants.json`` file
+that is used by clients to efficiently obtain the variant metadata
+without having to download it from individual wheels separately, or
+implement explicit variant metadata support on the package index
+software.
+
+
 Example use cases
 -----------------
 

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -944,48 +944,50 @@ distinguishable from regular variants.
 Install-time and Ahead-of-Time providers
 ----------------------------------------
 
-The specification covers two related use cases for package variants:
+The variant wheel metadata specifies what providers are used for its
+properties. Providers serve twofold purpose:
 
-1. Variants that need to query the user system to determine their
-   compatibility with it. For example, these are the variants utilizing
-   GPUs or requiring CPU instruction sets beyond what platform tags
-   provide.
+a. at install time: determining which variant wheels are compatible with
+   the user's system, and which of them constitutes the best choice, and
 
-2. Variants that can always be installed, and therefore only provide a
-   choice between different installation options. For example, software
-   built against different BLAS / LAPACK providers or debug builds of
-   packages.
+b. at build time: determining which variant properties are valid for
+   building a wheel.
 
-The first class of variants requires querying provider plugins to
-determine package compatibility, and therefore involves the potential
-risks highlighted in the `security implications`_ section. The proposed
-mitigations incur a cost on installer implementations, making it
-desirable to avoid plugin use at install time for the second class of
-variants, where it is not strictly necessary.
+The specification proposes two kinds of providers: install-time
+providers and Ahead-of-Time providers.
 
-To account for this, the specification proposes two classes of
-providers:
+Install-time providers are implemented either as Python packages that
+need to be installed and ran to query them, or vendored or reimplemented
+in the tools. They are used when user systems need to be queried to
+determine wheel compatibility, for example for variants utilizing GPUs
+or requiring CPU instruction sets beyond what platform tags provide.
+Installing third-party packages involves security risks highlighted in
+the `security implications`_ section, and the proposed mitigations incur
+a cost on installer implementations.
 
-a. Install-time providers that require executing code to determine
-   the wheel compatibility, and therefore satisfy the variants needing
-   that.
-
-b. Ahead-of-Time (AoT) providers that entirely rely on static metadata
-   for the purpose of wheel selection, and that can be used for the
-   other class of variants to avoid the additional problems posed
-   by install-time providers.
+Ahead-of-Time providers are implemented as static metadata embedded in
+the wheel. They are used when particular variant properties are always
+compatible with the user's system (provided that a wheel using them has
+been built successfully). However, the metadata indicates which
+properties are preferred. For example, AoT providers can be used to
+provide choice between builds against different BLAS / LAPACK providers,
+or to provide debug builds of packages. Since they do not require
+running code external to the installer, they do not pose the problems
+faced by install-time providers, and can be used more liberally.
 
 For user convenience and better consistency across different packages,
-AoT providers can also feature plugin packages, but they are only used
-at build time (where executing code from additional packages is already
-a risk) to verify the variant properties specified by the maintainer
-and automatically generate the static metadata.
+AoT providers are permitted to feature plugin packages. If that is the
+case, these packages are only used when building wheels, and their
+output is used to fill in the static metadata used at install time.
+Otherwise, the package maintainer needs to include this metadata
+straight in ``pyproject.toml`` file.
 
-Both kinds of provider plugins expose the same API. However, an AoT
-provider must always consider all valid variant properties supported,
-and it must always return the same ordered list of supported properties
-irrespective of the user system. All AoT providers can be technically
-used as install-time providers, but not the other way around.
+When implemented as Python packages, both kinds of provider plugins
+roughly expose the same API. However, an AoT provider must always
+consider all valid variant properties supported, and it must always
+return the same ordered list of supported properties irrespective of the
+user system. All AoT providers can be technically used as install-time
+providers, but not the other way around.
 
 
 Plugin stability and versioning

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1021,11 +1021,11 @@ the external plugin when the package in question is incompatible with
 the installer's implementation.
 
 
-Metadata in project tree and wheels
+Metadata in source tree and wheels
 -----------------------------------
 
 Variants introduce a few new portions of metadata that are stored in the
-project tree and in wheels. In the project tree, it is stored in the
+source tree and in wheels. In the source tree, it is stored in the
 ``pyproject.toml`` file along with other project properties, benefiting
 from the TOML format's readability and strictness. Afterwards, it is
 converted into an equivalent JSON structure, and stored as a separate

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -1203,41 +1203,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 document are to be interpreted as described in :rfc:`2119`.
 
 
-Things to include again
------------------------
-
-Installers, as well as other tools that need to verify variant wheel
-compatibility and are run in security-sensitive context, MUST NOT
-install or run code from any untrusted package for variant resolution
-without explicit user opt-in. Provider packages SHOULD take measures to
-guard against supply chain attacks, for example by vendoring all
-dependencies. Pinning dependencies is discouraged to comply with
-:pep:`517`
-build process, as provider plugins MAY be needed at build time and
-dependencies pinned to different versions could prevent different
-plugins from being installed simultaneously in the same environment.
-
-It is RECOMMENDED that these tools vendor, reimplement or lock the most
-commonly used plugins to specific wheels after verifying
-their trustworthiness, to enable the ability to securely install variant
-wheels out-of-the-box. To reduce the maintenance costs, repositories of
-such vetted plugins could be maintained collaboratively and shared
-between different tools.
-
-For plugins and their dependencies not in such a pre-approved list,
-a trust-on-first-use mechanism for every version is RECOMMENDED. In
-interactive sessions, the tool can explicitly ask the user for approval.
-In non-interactive sessions, the approval can be given using
-command-line interface options. It is important that the user is
-informed of the risk before giving such an approval.
-
-For a consistent experience between tools, variant wheels SHOULD be
-supported by default. Tools MAY provide an option to only use
-non-variant wheels. For scenarios requiring more control, providers can
-be marked as optional and then must be explicitly enabled by the user
-for the wheels to become available for installation.
-
-
 Extended wheel filename
 -----------------------
 
@@ -1330,6 +1295,46 @@ Examples:
     # additionally, at least one of the following must be supported
     nvidia :: sm_arch :: 120_real
     nvidia :: sm_arch :: 110_real
+
+
+Providers
+---------
+
+When installing variant wheels, installers SHOULD verify whether a given
+wheel's properties are compatible with the system in question by
+querying the variant providers, though they MAY provide an option to
+omit the verification. Having to select between multiple variant wheels,
+they MUST perform said verification and `variant ordering`_.
+
+All the tools that need to query variant providers and are run in a
+security-sensitive context, MUST NOT install or run code from any
+untrusted package for variant resolution without explicit user opt-in.
+Provider packages SHOULD take measures to guard against supply chain
+attacks, for example by vendoring all dependencies. Pinning dependencies
+is discouraged to comply with :pep:`517` build process, as provider
+plugins may be needed at build time and dependencies pinned to different
+versions could prevent different plugins from being installed
+simultaneously in the same environment.
+
+It is RECOMMENDED that said tools vendor, reimplement or lock the most
+commonly used plugins to specific wheels after verifying
+their trustworthiness, to enable the ability to securely install variant
+wheels out-of-the-box. To reduce the maintenance costs, repositories of
+such vetted plugins could be maintained collaboratively and shared
+between different tools.
+
+For plugins and their dependencies that are neither reimplemented,
+vendored nor otherwise vetted, a trust-on-first-use mechanism for every
+version is RECOMMENDED. In interactive sessions, the tool can explicitly
+ask the user for approval. In non-interactive sessions, the approval
+can be given using command-line interface options. It is important that
+the user is informed of the risk before giving such an approval.
+
+For a consistent experience between tools, variant wheels SHOULD be
+supported by default. Tools MAY provide an option to only use
+non-variant wheels. For scenarios requiring more control, providers can
+be marked as optional and then must be explicitly enabled by the user
+for the wheels to become available for installation.
 
 
 Variant metadata

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -716,37 +716,6 @@ build against.
 Rationale
 =========
 
-Summary of changes
--------------------
-
-The Wheel Variant PEP introduces four key components:
-
-1. `Extended wheel filename`_: Variant wheels include a variant label
-   in their filename to ensure:
-
-   a. that every distinct variant has a unique filename
-   b. that variant wheels are not accidentally installed by
-      non-variant-aware tools.
-
-2. `Variant metadata`_ format: Standardized metadata describing variant
-   properties and provider requirements.
-
-   a. Metadata specification at "project level" inside
-      ``pyproject.toml``
-   b. Metadata specification of "built packages" inside two JSON files:
-
-      i. ``*.dist-info/variant.json``: Individual wheel variant
-         metadata.
-      ii. ``*-variants.json``: Variant metadata file aggregated on the
-          package index.
-
-3. `Provider plugin API`_: Plugin interface to allow detection of
-   system capabilities and validate variant compatibility.
-
-4. `Variant environment markers`_: New environment markers to declare
-   dependencies that are applicable to a subset of variants only.
-
-
 Wheel variant glossary
 ----------------------
 

--- a/peps/pep-0817.rst
+++ b/peps/pep-0817.rst
@@ -858,6 +858,19 @@ Uppercase characters are disallowed to avoid different spellings of the
 same name. The character set for values is more relaxed, to permit
 values resembling versions.
 
+Variant properties are serialized into a structured 3-tuple format
+inspired by Trove Classifiers in :pep:`301`:
+
+.. code-block:: text
+
+    {namespace} :: {feature_name} :: {feature_value}
+
+Properties are used both to determine variant wheel compatibility, and
+to select the best variant to install. Provider plugins indicate which
+variant properties are compatible with the system, and order them by
+importance. This ordering can further be altered in variant wheel
+metadata.
+
 Variant features can be declared as allowing multiple values to be
 present within a single variant wheel. If that is the case, these values
 are matched as a logical OR, i.e. only a single value needs to
@@ -867,39 +880,58 @@ need to be compatible. This provides some flexibility in designating
 variant compatibility while avoiding having to implement a complete
 boolean logic.
 
-Variant properties are serialized into a structured 3-tuple format
-inspired by Trove Classifiers in :pep:`301`:
+Typically, variant features will be single-value and indicate minimal or
+mutually exclusive requirements. The system may indicate multiple
+compatible values. For example, if the feature declares a minimum CUDA
+runtime version, the provider will indicate compatibility with wheels
+requiring a minimum version corresponding to the currently installed
+version or older, e.g. for CUDA 12.8, the compatible minimum versions
+used in wheels would be, in order of decreasing preference:
 
 .. code-block:: text
 
-    {namespace} :: {feature_name} :: {feature_value}
+    nvidia :: cuda_version_lower_bound :: 12.8
+    nvidia :: cuda_version_lower_bound :: 12.7
+    nvidia :: cuda_version_lower_bound :: 12.6
+    ...
+
+Similarly, a wheel could indicate its minimum required CPU version, and
+the provider will indicate all the compatible CPU versions.
+
+Multi-value features are useful for "fat" packages where multiple
+incompatible targets are supported by a single package. A typical
+example are GPUs. In this case, the wheel declares a number of supported
+GPUs, and the provider indicates which GPUs are actually installed
+(usually one). The wheel is compatible if there is overlap between the
+two lists.
 
 
 Null variant
 ------------
 
-The concept of a null variant makes it possible to distinguish a
-fallback wheel variant from a regular wheel published for backwards
-compatibility. For example, a package that features optional GPU support
-could publish the following wheels during the transition period:
+A null variant is a variant wheel with no properties, but distinct
+from non-variant wheels in having the ``null`` variant label and variant
+metadata. During the transition period, it provides the possibility of
+providing a distinct fallbacks for systems that do not support any of
+the variants provided, and for systems that do support variant wheels at
+all.
 
-- One or more wheel variants built for specific hardware, that will be
-  installed on systems with an installer supporting variants and
-  suitable hardware.
+For example, a package with optional GPU support could publish three
+kinds of wheels:
 
-- A CPU-only null variant, that will be installed on systems with an
-  installer supporting variants, but without hardware suitable for any
-  other variants.
+- Multiple GPU-enabled wheels, each built for a single CUDA version with
+  a matching set of supported GPUs, and used only when the provider
+  plugin indicates that the system is compatible.
 
-- A GPU+CPU regular wheel, that will be installed on systems without an
-  installer supporting variants.
+- A CPU-only null variant, much smaller than the GPU variants, installed
+  when the provider plugin indicates that no compatible GPU is
+  installed.
 
-Notably, this makes it possible to publish a smaller null variant for
-systems that do not feature suitable hardware, with a fallback regular
-wheel with support for CPU and all GPUs for systems where variants are
-not supported and therefore GPU support cannot be determined.
+- A GPU+CPU non-variant wheel, that will be installed on systems without
+  an installer supporting variants.
 
-Publishing a null variant is optional. If one is published, a wheel
+Publishing a null variant is optional, and makes sense only if distinct
+fallbacks provide advantages to the user. If one is published, a wheel
 variant-enabled installer will prefer it over the non-variant wheel. If
 it is not, it will fall back to the non-variant wheel instead. The
 non-variant wheel is also used if variant support is explicitly disabled
@@ -1275,9 +1307,10 @@ ASCII Characters (``^[a-z0-9_.]+$``). It MUST correspond to a valid
 value defined by the respective variant provider for the feature.
 
 If a feature is marked as "multi-value" by the provider plugin, a single
-variant wheel MAY define multiple properties sharing the same namespace
-and feature name. Otherwise, only a single value can correspond to a
-single pair of namespace and feature name within a variant wheel.
+variant wheel can define multiple properties sharing the same namespace
+and feature name. Otherwise, there MUST NOT be more than a single value
+corresponding to a single pair of namespace and feature name within a
+variant wheel.
 
 For a variant wheel to be considered compatible with the system, all of
 the features defined within it MUST be determined to be compatible. For


### PR DESCRIPTION
Per the feedback, try to make a better split of rationale/specification.

Notably, at this point Rationale tries to introduce all the important concepts, so it's mostly standalone. After reading it, one should have an idea of all the important concepts, and need Specification only to learn the details of how to implement them.

I've also noticed we're not really covering the use of providers in sufficient detail in the specification section, so expanded on the appropriate MUSTs and SHOULDs.

Potential TODO: we may also want to mention environment markers and ABI namespace in Rationale.