### PR TITLE
Clarify that the exact URL used to host `variants.json` is insignificant

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -302,14 +302,14 @@ Index-level metadata
 
 For every package version that includes at least one variant wheel,
 there MUST exist a corresponding ``{name}-{version}-variants.json``
-file, hosted and served by the package index. The ``{name}`` and
-``{version}`` placeholders correspond to the package name and version,
-normalized according to the same rules as wheel files, as found in the
-:ref:`packaging:wheel-file-name-spec` of the Binary Distribution Format
-specification. The link to this file MUST be present on all index pages
-where the variant wheels are linked. It is presented in the same simple
-repository format as source distribution and wheel links in the index,
-including an (OPTIONAL) hash.
+file. The ``{name}`` and ``{version}`` placeholders correspond to the
+package name and version, normalized according to the same rules as
+wheel files, as found in the :ref:`packaging:wheel-file-name-spec` of
+the Binary Distribution Format specification. The exact URL where the
+file is hosted is insignificant, but a link to it MUST be present on all
+index pages where the variant wheels are linked. It is presented in the
+same simple repository format as source distribution and wheel links in
+the index, including an (OPTIONAL) hash.
 
 This file uses the same structure as `variant metadata`_, except that
 the ``variants`` object MUST list all variants available on the package


### PR DESCRIPTION
Per the discussion with @dstufft, the current wording may be confusing as to where the file needs to resides. Clarify that -- same as wheels themselves -- it can be hosted anywhere, as long as the URL is present.

<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--42.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->