### PR TITLE
[variant-json] made mutable with vendoring/inlining

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -186,7 +186,7 @@ version number is stored as part of the schema_ URL. Whenever the format
 changes, the version number must be incremented. Tools MUST assume that
 all variant wheels using an unknown format version are unsupported.
 
-The version numbers starting with zero are reserved for drafts and SHOULD
+The version numbers starting with zero are reserved for drafts and MUST
 NOT be used in production. Once the proposal is complete, the latest
 draft will be promoted to version ``1.0.0``.
 
@@ -634,14 +634,11 @@ Variant wheels can be listed in ``pylock.toml`` file in the same manner
 as wheels with different Platform compatibility tags: either all variant
 (and non-variant) wheels can be listed, or a subset of them.
 
-A new ``[packages.variants-json]`` subtable is added to the file. As the
-``{name}-{version}-variants.json`` file CAN be mutable, linking to the file
-is not sufficient, ``pylock.toml`` MUST inline the content of the
-``{name}-{version}-variants.json`` directly into ``pylock.toml``. Effectively
-locking the content of the ``{name}-{version}-variants.json`` file itself
-instead of the URL of the file with its hash (which can change). Doing so
-also guarantee the highest performance possible by avoiding network calls
-at install time.
+A new ``[packages.variants-json]`` subtable is added to the file. It MUST
+inline the content of the ``{name}-{version}-variants.json`` file, converting
+the JSON structure into the respective TOML types. The ``$schema`` key MUST
+be preserved to facilitate versioning. The tools MAY remove keys that are not
+relevant to variant wheels present in ``pylock.toml``.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.
@@ -655,6 +652,7 @@ follows:
 - **Type**: table
 - **Required?**: no
 - **Functions**:
+
   - Inline variant selection metadata for the package.
   - The structure of this table MUST conform to the JSON Schema.
   - Tools that support variant-aware resolution MUST validate this table

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -998,6 +998,8 @@ Change History
     rather than all compatible values, and add a fallback to ordering
     on variant label.
   - Removed the variant label length limitation.
+  - Changed ``pylock.toml`` integration to inline variant metadata
+    rather than storing a URL and a hash.
 
 
 Appendices

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -643,11 +643,15 @@ that are not relevant to variant wheels present in ``pylock.toml``.
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.
 
+
+Proposed specification update
+'''''''''''''''''''''''''''''
+
 The proposed text for :doc:`packaging:specifications/pylock-toml`
 follows:
 
 ``[packages.variant_json]``
-'''''''''''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Type**: table
 - **Required?**: no
@@ -659,6 +663,38 @@ follows:
     against the referenced schema.
   - Tools that do not support variant-aware resolution MAY ignore this table
     but SHOULD preserve it when rewriting the lock file.
+
+
+Example
+'''''''
+
+.. code:: toml
+
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.14"
+
+    [[packages]]
+    name = "numpy"
+    version = "2.3.4"
+    index = "https://pypi.anaconda.org/mgorny/simple"
+    wheels = [
+        { url = "https://pypi.anaconda.org/mgorny/simple/numpy/2.3.4/numpy-2.3.4-cp314-cp314-linux_x86_64-openblas.whl", hashes = {} },
+        { url = "https://pypi.anaconda.org/mgorny/simple/numpy/2.3.4/numpy-2.3.4-cp314-cp314-linux_x86_64-x8664v4_mkl.whl", hashes = {} },
+        { url = "https://pypi.anaconda.org/mgorny/simple/numpy/2.3.4/numpy-2.3.4-cp314-cp314-macosx_13_0_x86_64-accelerate.whl", hashes = {} },
+        { url = "https://pypi.anaconda.org/mgorny/simple/numpy/2.3.4/numpy-2.3.4-cp314-cp314-macosx_13_0_x86_64-openblas.whl", hashes = {} },
+    ]
+
+    [packages.variant_json]
+    "$schema" = "https://variants-schema.wheelnext.dev/peps/825/v0.1.0.json"
+
+    [packages.variant_json.default-priorities]
+    namespace = [ "x86_64", "aarch64", "blas_lapack" ]
+
+    [packages.variant_json.variants]
+    null = { }
+    x8664v3_openblas = { "blas_lapack" = { "library" = ["openblas"]}, "x86_64" = { "level" = ["v3"]}  }
+    x8664v4_mkl = { "blas_lapack" = { "library" = ["mkl"]}, "x86_64" = { "level" = ["v4"]}  }
 
 
 Suggested implementation logic for tools (non-normative)

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -724,9 +724,9 @@ There are two possible approaches to publishing the index-level
 it can either be prepared and uploaded by the user, or it can be
 generated automatically by the index.
 
-The file should not be changed once it is published, as clients may have
-already cached it or locked to the existing hash. For this reason, if
-the index is responsible for generating the file, it should use some
+Since the clients may cache the file at any point, it is recommended not
+to publish it until it contains the metadata for all variants. If the
+index is responsible for generating the file, it should use some
 mechanism to defer publishing it until the release is fully uploaded
 (for example, :pep:`694`).
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -321,12 +321,12 @@ or they may carefully merge their values, provided that no conflicting
 information is introduced, and the resolution results within a subset of
 variants do not change.
 
+This file SHOULD NOT be considered immutable and MAY be updated in a
+backward compatible way at any point (e.g. when adding a new variant).
+
 Variant indexes MAY elect to either auto-generate the file from the
 uploaded variant wheels or allow the user to manually generate it
 themselves and upload it to the index.
-
-This file SHOULD NOT be considered immutable and MAY BE updated in
-a backward compatible way at any point (e.g. adding a new type of variant).
 
 The ``foo-1.2.3-variants.json`` corresponding to the package with two
 wheel variants, one of them listed in the previous example, would look
@@ -634,11 +634,12 @@ Variant wheels can be listed in ``pylock.toml`` file in the same manner
 as wheels with different Platform compatibility tags: either all variant
 (and non-variant) wheels can be listed, or a subset of them.
 
-A new ``[packages.variants-json]`` subtable is added to the file. It MUST
-inline the content of the ``{name}-{version}-variants.json`` file, converting
-the JSON structure into the respective TOML types. The ``$schema`` key MUST
-be preserved to facilitate versioning. The tools MAY remove keys that are not
-relevant to variant wheels present in ``pylock.toml``.
+A new ``[packages.variants-json]`` subtable is added to the file. It
+MUST inline the content of the ``{name}-{version}-variants.json`` file,
+converting the JSON structure into the respective TOML types. The
+``$schema`` key MUST be preserved to facilitate versioning. The tools
+MAY remove keys that are not relevant to variant wheels present in
+``pylock.toml``.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -760,9 +760,7 @@ There are two possible approaches to publishing the index-level
 it can either be prepared and uploaded by the user, or it can be
 generated automatically by the index.
 
-Since the clients may cache the file at any point, it is recommended not
-to publish it until it contains the metadata for all variants. If the
-index is responsible for generating the file, it should use some
+If the index is responsible for generating the file, it should use some
 mechanism to defer publishing it until the release is fully uploaded
 (for example, :pep:`694`).
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -635,11 +635,10 @@ as wheels with different Platform compatibility tags: either all variant
 (and non-variant) wheels can be listed, or a subset of them.
 
 A new ``[packages.variants-json]`` subtable is added to the file. It
-MUST inline the content of the ``{name}-{version}-variants.json`` file,
-converting the JSON structure into the respective TOML types. The
-``$schema`` key MUST be preserved to facilitate versioning. The tools
-MAY remove keys that are not relevant to variant wheels present in
-``pylock.toml``.
+MUST inline the contents of the `index-level metadata`_ file, converting
+the JSON structure into the respective TOML types. The ``$schema`` key
+MUST be preserved to facilitate versioning. The tools MAY remove keys
+that are not relevant to variant wheels present in ``pylock.toml``.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -186,7 +186,7 @@ version number is stored as part of the schema_ URL. Whenever the format
 changes, the version number must be incremented. Tools MUST assume that
 all variant wheels using an unknown format version are unsupported.
 
-The version numbers starting with zero are reserved for drafts and MUST
+The version numbers starting with zero are reserved for drafts and SHOULD
 NOT be used in production. Once the proposal is complete, the latest
 draft will be promoted to version ``1.0.0``.
 
@@ -324,6 +324,9 @@ variants do not change.
 Variant indexes MAY elect to either auto-generate the file from the
 uploaded variant wheels or allow the user to manually generate it
 themselves and upload it to the index.
+
+The variant JSON SHOULD NOT be considered immutable and MAY BE updated in
+a backward compatible way at any point (e.g. adding a new type of variant).
 
 The ``foo-1.2.3-variants.json`` corresponding to the package with two
 wheel variants, one of them listed in the previous example, would look
@@ -631,10 +634,14 @@ Variant wheels can be listed in ``pylock.toml`` file in the same manner
 as wheels with different Platform compatibility tags: either all variant
 (and non-variant) wheels can be listed, or a subset of them.
 
-A new ``[packages.variants-json]`` subtable is added to the file, to
-permit locking the ``{name}-{version}-variants.json`` file to a specific
-hash. If variant wheels are listed for a given package, the tool SHOULD
-lock this file as well.
+A new ``[packages.variants-json]`` subtable is added to the file. As the
+``{name}-{version}-variants.json`` file CAN be mutable, linking to the file
+is not sufficient, ``pylock.toml`` MUST inline the content of the
+``{name}-{version}-variants.json`` directly into ``pylock.toml``. Effectively
+locking the content of the ``{name}-{version}-variants.json`` file itself
+instead of the URL of the file with its hash (which can change). Doing so
+also guarantee the highest performance possible by avoiding network calls
+at install time.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.
@@ -642,41 +649,18 @@ the best wheel file.
 The proposed text for :doc:`packaging:specifications/pylock-toml`
 follows:
 
-.. code:: rst
+``[packages.variant_json]``
+---------------------------
 
-    .. _pylock-packages-variants-json:
-
-    ``[packages.variants-json]``
-    ----------------------------
-
-    - **Type**: table
-    - **Required?**: no; requires that :ref:`pylock-packages-wheels` is used,
-     mutually-exclusive with :ref:`pylock-packages-vcs`,
-     :ref:`pylock-packages-directory`, and :ref:`pylock-packages-archive`.
-    - **Inspiration**: uv_
-    - The URL or path to the ``variants.json`` file.
-    - Only used if the project uses :ref:`wheel variants <wheel-variants>`.
-
-    .. _pylock-packages-variants-json-url:
-
-    ``packages.variants-json.url``
-    ''''''''''''''''''''''''''''''
-
-    See :ref:`pylock-packages-archive-url`.
-
-    .. _pylock-packages-variants-json-path:
-
-    ``packages.variants-json.path``
-    '''''''''''''''''''''''''''''''
-
-    See :ref:`pylock-packages-archive-path`.
-
-    .. _pylock-packages-variants-json-hashes:
-
-    ``packages.variants-json.hashes``
-    '''''''''''''''''''''''''''''''''
-
-    See :ref:`pylock-packages-archive-hashes`.
+- **Type**: table
+- **Required?**: no
+- **Functions**:
+  - Inline variant selection metadata for the package.
+  - The structure of this table MUST conform to the JSON Schema.
+  - Tools that support variant-aware resolution MUST validate this table
+  against the referenced schema.
+  - Tools that do not support variant-aware resolution MAY ignore this table
+  but SHOULD preserve it when rewriting the lock file.
 
 
 Suggested implementation logic for tools (non-normative)

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -325,7 +325,7 @@ Variant indexes MAY elect to either auto-generate the file from the
 uploaded variant wheels or allow the user to manually generate it
 themselves and upload it to the index.
 
-The variant JSON SHOULD NOT be considered immutable and MAY BE updated in
+This file SHOULD NOT be considered immutable and MAY BE updated in
 a backward compatible way at any point (e.g. adding a new type of variant).
 
 The ``foo-1.2.3-variants.json`` corresponding to the package with two

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -795,6 +795,13 @@ wheels being unsupported altogether. For example, PyTorch could provide
 a much smaller null variant that is used when no GPU is supported, and a
 fallback non-variant wheel built for the default CUDA version.
 
+``pylock.toml`` integration inlines the variant metadata to keep the
+file standalone. This can avoid the additional network call that would
+be required to fetch the file, and avoids having to pin to a specific
+hash that could cause problems if the file changed on the index, either
+due to the variant metadata being updated or being generated in a way
+that does not guarantee stable bytewise output.
+
 
 Backwards Compatibility
 =======================

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -657,9 +657,9 @@ follows:
   - Inline variant selection metadata for the package.
   - The structure of this table MUST conform to the JSON Schema.
   - Tools that support variant-aware resolution MUST validate this table
-  against the referenced schema.
+    against the referenced schema.
   - Tools that do not support variant-aware resolution MAY ignore this table
-  but SHOULD preserve it when rewriting the lock file.
+    but SHOULD preserve it when rewriting the lock file.
 
 
 Suggested implementation logic for tools (non-normative)

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -647,7 +647,7 @@ The proposed text for :doc:`packaging:specifications/pylock-toml`
 follows:
 
 ``[packages.variant_json]``
----------------------------
+'''''''''''''''''''''''''''
 
 - **Type**: table
 - **Required?**: no


### PR DESCRIPTION


<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--43.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->