### PR TITLE
PEP 825: clarifications

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -245,7 +245,8 @@ present in that wheel's filename.
 
 It has 3 levels. The first level keys are variant labels, the second
 level keys are namespaces, the third level are feature names, and the
-third level values are lists of feature values.
+third level values are sets of feature values, converted to lists,
+sorted lexically.
 
 
 Example
@@ -802,6 +803,10 @@ the variant metadata is mirrored in a JSON file published on the index.
 This enables installers to obtain variant property mapping without
 having to fetch individual wheels.
 
+Since JSON format does not feature a set type, sets are represented as
+sorted lists. Sorting ensures that tools can safely use equality
+comparison over dictionaries.
+
 The variant ordering algorithm has been proposed with the assumption
 that variant properties take precedence over Platform compatibility
 tags, as they are primarily used to express user preferences. This
@@ -987,6 +992,11 @@ and Zanie Blue.
 
 Change History
 ==============
+
+- TO BE PUBLISHED
+
+  - Clarified that feature values in ``variants`` dictionary are sets,
+    and that they ought to be sorted when serializing.
 
 - 17-Feb-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -319,8 +319,8 @@ the variant metadata across multiple variant wheels of the same package
 version and the index-level metadata file is consistent. They MAY
 require that keys other than ``variants`` have exactly the same values,
 or they may carefully merge their values, provided that no conflicting
-information is introduced, and the resolution results within a subset of
-variants do not change.
+information is introduced, and the result is the same irrespective of
+the order in which the wheels are processed.
 
 This file SHOULD NOT be considered immutable and MAY be updated in a
 backward compatible way at any point (e.g. when adding a new variant).
@@ -997,6 +997,9 @@ Change History
 
   - Clarified that feature values in ``variants`` dictionary are sets,
     and that they ought to be sorted when serializing.
+  - Changed the rule for merging variant metadata to state that the
+    result must be the same irrespective of wheel order. This conveys
+    the goal of avoiding ambiguous results clearer.
 
 - 17-Feb-2026
 


### PR DESCRIPTION
Two changes I've mentioned on Slack today:

1. Make value lists in `variants` sorted, since the values are actually sets and this makes it easy to use `==` without having to convert everything back into sets. This matches the current behavior of variantlib.
2. Change the merging rule to say "result is the same irrespective of the order in which the wheels are processed". I think it's essentially a better way of wording the same goal (lack of ambiguity) than my original thought.

I'm opening the PR against "acceptance" branch for local review. We can then open it against upstream repo.

<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--45.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->