### PR TITLE
PEP 825: clarify that the feature and value lists will be ordered

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -384,9 +384,10 @@ the presence of variant metadata.
 
 For the purpose of ordering, variant properties are grouped into
 features, and features into namespaces. For every namespace, the tool
-MUST obtain an ordered list of compatible features, and for every
-feature, an ordered list of compatible values. The method of obtaining
-these lists will be defined in a subsequent PEP.
+MUST obtain a list of compatible features, and for every feature, a list
+of compatible values. The method of obtaining these lists will be
+defined in a subsequent PEP. The items in these lists will be provided
+in specific order that will impact variant wheel ordering.
 
 The compatible wheels corresponding to a particular combination of
 package name, version and build number MUST be grouped by their variant
@@ -404,9 +405,10 @@ algorithm:
       value of the respective ``default-priorities.feature.{namespace}``
       key.
 
-   ii. Obtain the compatible feature names, in order. For every feature
-       name that is not present in the constructed list, append it to
-       the end.
+   ii. Take the ordered list of compatible feature names obtained
+       previously and iterate over it, in order. For every feature name
+       that is not present in the constructed list, append it to the
+       end.
 
    After this step, a list of ordered feature names is available for
    every namespace. This is ``feature_order`` in the example.
@@ -417,9 +419,9 @@ algorithm:
       of the respective
       ``default-priorities.property.{namespace}.{feature_name}`` key.
 
-   ii. Obtain the compatible feature values, in order. For every value
-       that is not present in the constructed list, append it to the
-       end.
+   ii. Take the ordered list of compatible feature values obtained
+       previously and iterate over it, in order. For every value that is
+       not present in the constructed list, append it to the end.
 
    After this step, a list of ordered property values is available for
    every feature. This is ``value_order`` in the example.


### PR DESCRIPTION
I've tried that make that as explicit and verbose as possible.

<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--50.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->