### PR TITLE
PEP 825: clarify index-level metadata in simple repository API

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -313,10 +313,12 @@ the Binary Distribution Format specification.
 The exact URL where the file is hosted is insignificant, but it MUST
 be provided in all the responses where the variant wheels are included.
 It should follow the rules for files in the
-:ref:`packaging:simple-repository-api`, except that the
-``core-metadata``, ``dist-info-metadata`` and ``requires-python`` MUST
-NOT be provided for it. If the file is marked as yanked (via
-``yanked``), the tools MUST behave as if it did not exist.
+:ref:`packaging:simple-repository-api`, except that the various metadata
+served by the index (such as ``core-metadata``, ``dist-info-metadata``,
+``requires-python`` or ``yanked``) are not meaningful for that file.
+Indexes MAY publish or skip these attributes, as long as the values do
+not prevent correct operation. Tools MAY either use or ignore these
+values.
 
 This file uses the same structure as `variant metadata`_, except that
 the ``variants`` object MUST list all variants available on the package

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -304,13 +304,11 @@ Index-level metadata
 --------------------
 
 For every package version that includes at least one variant wheel,
-there SHOULD exist a corresponding ``{name}-{version}-variants.json``
+there MUST exist a corresponding ``{name}-{version}-variants.json``
 file. The ``{name}`` and ``{version}`` placeholders correspond to the
 package name and version, normalized according to the same rules as
 wheel files, as found in the :ref:`packaging:wheel-file-name-spec` of
-the Binary Distribution Format specification. If the file does not
-exist, the tools MUST assume that all variant wheels for the
-corresponding package version on this index are incompatible.
+the Binary Distribution Format specification.
 
 The exact URL where the file is hosted is insignificant, but it MUST
 be provided in all the responses where the variant wheels are included.

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -304,15 +304,21 @@ Index-level metadata
 --------------------
 
 For every package version that includes at least one variant wheel,
-there MUST exist a corresponding ``{name}-{version}-variants.json``
+there SHOULD exist a corresponding ``{name}-{version}-variants.json``
 file. The ``{name}`` and ``{version}`` placeholders correspond to the
 package name and version, normalized according to the same rules as
 wheel files, as found in the :ref:`packaging:wheel-file-name-spec` of
-the Binary Distribution Format specification. The exact URL where the
-file is hosted is insignificant, but a link to it MUST be present on all
-index pages where the variant wheels are linked. It is presented in the
-same simple repository format as source distribution and wheel links in
-the index, including an (OPTIONAL) hash.
+the Binary Distribution Format specification. If the file does not
+exist, the tools MUST assume that all variant wheels for the
+corresponding package version on this index are incompatible.
+
+The exact URL where the file is hosted is insignificant, but it MUST
+be provided in all the responses where the variant wheels are included.
+It should follow the rules for files in the
+:ref:`packaging:simple-repository-api`, except that the
+``core-metadata``, ``dist-info-metadata`` and ``requires-python`` MUST
+NOT be provided for it. If the file is marked as yanked (via
+``yanked``), the tools MUST behave as if it did not exist.
 
 This file uses the same structure as `variant metadata`_, except that
 the ``variants`` object MUST list all variants available on the package


### PR DESCRIPTION
Clarify the description for index-level metadata to precisely refer to the Simple repository API specification.  Make it more generic to fit both the HTML and JSON responses.  Indicate that wheel-specific data is to be ignored.  Explicitly account for files being either missing or yanked, indicating that variant wheels should not be used then.

<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--51.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->