### PR TITLE
Open issues -> Out of scope

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1061,8 +1061,8 @@ justifies the benefit of more compact, and slightly more consistent
 naming.
 
 
-Open Issues
-===========
+Out of scope
+------------
 
 The following problems are deferred to subsequent PEPs in the series:
 
@@ -1070,7 +1070,7 @@ The following problems are deferred to subsequent PEPs in the series:
 - determining which variant properties are compatible with the system
 - building variant wheels
 
-In addition to that, the following issues are left undefined:
+In addition to that, the following questions are left undefined:
 
 - Selecting variant wheels from multiple sources. Currently, there is no
   standard defined behavior for regular wheels, nor consensus across

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1004,7 +1004,7 @@ Reference Implementation
 The `variantlib <https://github.com/wheelnext/variantlib>`__ project
 contains a reference implementation of a complete variant wheel
 solution. It is compliant with this PEP, but also goes beyond it,
-providing example solutions to `open issues`_.
+providing example solutions to some of deferred items.
 
 A client for installing variant wheels is implemented in a
 `uv branch <https://github.com/astral-sh/uv/pull/12203>`__.


### PR DESCRIPTION
Paul Moore helpfully reminded me that "Open Issues" is for draft PEPS. I moved the things that arte not implemented to "Rejected Ideas" instead. It doesn't belong there either, but it's the best fitting location in the current PEP template.

<!-- readthedocs-preview wheelnext-peps start -->
----
📚 Documentation preview 📚: https://wheelnext-peps--56.org.readthedocs.build/

<!-- readthedocs-preview wheelnext-peps end -->