### PR TITLE
PEP 825: add "static data" to problems deferred to the next PEP

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1068,6 +1068,7 @@ The following problems are deferred to subsequent PEPs in the series:
 
 - governance of variant namespaces
 - determining which variant properties are compatible with the system
+- overriding the compatibility detection using static data
 - building variant wheels
 
 In addition to that, the following matters are left


### PR DESCRIPTION
Given it came up more than once already, I suppose it makes sense to point it out explicitly, even though it technically falls under "compatibility".