### PR TITLE
PEP 825: clarify variant metadata scopes

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -194,6 +194,10 @@ draft will be promoted to version ``1.0.0``.
 
 The top-level keys are described in the subsequent sections.
 
+Except where noted otherwise, variant metadata is project-scoped. It is
+copied into individual variant wheels, but it MUST be consistent across
+different variant wheels created for a particular project version.
+
 
 Schema
 ''''''
@@ -242,8 +246,9 @@ Variants
 ''''''''
 
 The ``variants`` dictionary provides a mapping from variant labels
-to variant properties. In the variant wheel, it MUST contain the label
-present in that wheel's filename.
+to variant properties. In an individual variant wheel, it is scoped to
+that wheel and it MUST contain the label present in that wheel's
+filename.
 
 It has 3 levels. The first level keys are variant labels, the second
 level keys are namespaces, the third level are feature names, and the
@@ -321,14 +326,14 @@ as long as the values do not prevent correct operation. Tools MAY either
 use or ignore these values.
 
 This file uses the same structure as `variant metadata`_, except that
-the ``variants`` object MUST list all variants available on the package
-index for the package version in question. The tools MUST ensure that
-the variant metadata across multiple variant wheels of the same package
-version and the index-level metadata file is consistent. They MAY
-require that keys other than ``variants`` have exactly the same values,
-or they may carefully merge their values, provided that no conflicting
-information is introduced, and the result is the same irrespective of
-the order in which the wheels are processed.
+the ``variants`` object is index-scope and it MUST list all variants
+available on the package index for the package version in question. The
+tools MUST ensure that the variant metadata across multiple variant
+wheels of the same package version and the index-level metadata file is
+consistent. They MAY require that keys other than ``variants`` have
+exactly the same values, or they may carefully merge their values,
+provided that no conflicting information is introduced, and the result
+is the same irrespective of the order in which the wheels are processed.
 
 This file SHOULD NOT be considered immutable and MAY be updated in a
 backward compatible way at any point (e.g. when adding a new variant).


### PR DESCRIPTION
Tries to address the point made in https://github.com/wheelnext/peps/pull/60#issuecomment-4769165728. To be honest, I have mixed feelings about the result but maybe you have some ideas how to make this better.