### PR TITLE
PEP 825: Remove `feature` and `value` dicts from `default-priorities`

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -173,11 +173,6 @@ PEP defines the following structure:
     +- $schema
     +- default-priorities
     |  +- namespace        : list[str]
-    |  +- feature
-    |     +- {namespace}   : list[str]  = []
-    |  +- property
-    |     +- {namespace}
-    |        +- {feature}  : list[str]  = []
     +- variants
       +- {variant_label}
          +- {namespace}
@@ -228,19 +223,6 @@ The following key is REQUIRED:
   wheels for a given package version, ordered in decreasing priority.
   This list MUST contain all namespaces used in variant properties.
 
-It MAY have the following OPTIONAL keys:
-
-- ``feature: dict[str, list[str]]``: A dictionary with namespaces as
-  keys, and ordered list of corresponding feature names as values.
-  The feature names are ordered in decreasing priority. It is used to
-  override the default feature ordering.
-
-- ``property: dict[str, dict[str, list[str]]]``: A nested dictionary
-  with namespaces as first-level keys, feature names as second-level
-  keys and ordered lists of corresponding property values as
-  second-level values. The feature values are ordered in decreasing
-  priority. It is used to override the default value ordering.
-
 
 Variants
 ''''''''
@@ -271,20 +253,6 @@ Example
         // does not matter), and both are more important than specific BLAS/LAPACK
         // library:
         "namespace": ["x86_64", "aarch64", "blas_lapack"],
-
-        // OPTIONAL: makes "library" the most important feature in "blas_lapack"
-        // namespace
-        "feature": {
-          "blas_lapack": ["library"]
-        },
-
-        // OPTIONAL: makes ["mkl", "openblas"] the most important values of
-        // "blas_lapack :: library" feature
-        "property": {
-          "blas_lapack": {
-            "library": ["mkl", "openblas"]
-          }
-        }
       },
 
       "variants": {
@@ -410,32 +378,11 @@ algorithm:
    ``default-priorities.namespace`` key from `index-level metadata`_.
    This is ``namespace_order`` in the example.
 
-2. For every namespace:
+2. For every namespace, take the ordered list of compatible feature
+   names obtained previously. This is ``feature_order`` in the example.
 
-   i. Construct the initial ordered list of feature names by copying the
-      value of the respective ``default-priorities.feature.{namespace}``
-      key.
-
-   ii. Take the ordered list of compatible feature names obtained
-       previously and iterate over it, in order. For every feature name
-       that is not present in the constructed list, append it to the
-       end.
-
-   After this step, a list of ordered feature names is available for
-   every namespace. This is ``feature_order`` in the example.
-
-3. For every feature:
-
-   i. Construct the initial ordered list of values by copying the value
-      of the respective
-      ``default-priorities.property.{namespace}.{feature_name}`` key.
-
-   ii. Take the ordered list of compatible feature values obtained
-       previously and iterate over it, in order. For every value that is
-       not present in the constructed list, append it to the end.
-
-   After this step, a list of ordered property values is available for
-   every feature. This is ``value_order`` in the example.
+3. For every feature, take the order list of compatible values obtained
+   previously. This is ``value_order`` in the example.
 
 4. For every group, determine the most preferred value corresponding to
    every variant feature present in the variant properties corresponding
@@ -502,31 +449,22 @@ compatibility tags.
     # default-priorities dict from index-level metadata
     default_priorities = {
         "namespace": [...],  # : list[str]
-        "feature": {...},  # : dict[str, list[str]]
-        "property": {...},  # : dict[str, dict[str, list[str]]]
     }
 
-    # 1. Construct the ordered list of namespaces.
+    # 1. Obtain the ordered list of namespaces from the variant metadata.
     namespace_order = default_priorities["namespace"]
-    feature_order = {}
-    value_order = {}
-
-    for namespace in namespace_order:
-        # 2. Construct the ordered lists of feature names.
-        feature_order[namespace] = default_priorities["feature"].get(namespace, [])
-        for feature_name in get_compatible_feature_names(namespace):
-            if feature_name not in feature_order[namespace]:
-                feature_order[namespace].append(feature_name)
-
-        value_order[namespace] = {}
-        for feature_name in feature_order[namespace]:
-            # 3. Construct the ordered lists of feature values.
-            value_order[namespace][feature_name] = (
-                default_priorities["property"].get(namespace, {}).get(feature_name, [])
-            )
-            for feature_value in get_compatible_feature_values(namespace, feature_name):
-                if feature_value not in value_order[namespace][feature_name]:
-                    value_order[namespace][feature_name].append(feature_value)
+    # 2. Obtain the ordered lists of features.
+    feature_order = {
+        namespace: get_compatible_feature_names(namespace)
+        for namespace in namespace_order
+    }
+    # 3. Obtain the ordered lists of feature values.
+    value_order = {
+        namespace: {
+            feature_name: get_compatible_feature_values(namespace, feature_name)
+            for feature_name in feature_order[namespace]
+        } for namespace in namespace_order
+    }
 
 
     def best_value_property(namespace: str, feature_name: str, feature_values: str) -> str:
@@ -799,9 +737,6 @@ To generate the ``{name}-{version}-variants.json`` file:
    - common keys of these dictionaries must have exactly the same value
    - ``default-priorities.namespace`` list can be replaced if the new
      value starts with the old value
-   - ``default-priorities.feature`` and ``default-priorities.value``
-     keys can be added if they were not present in the previous
-     ``default-priorities.namespace`` value
 
 
 Installing wheels from multiple sources (non-normative)
@@ -946,9 +881,7 @@ provided. However, namespaces are governed independently and considered
 on equal footing, and therefore there will be no standard ordering for
 them. Instead, the ordering of namespaces will be explicitly stated in
 the variants metadata, which in turn will be provided by the package
-maintainer as part of the build process. For completeness, it will also
-be possible to provide overrides for the ordering of features and values
-via the same mechanism.
+maintainer as part of the build process.
 
 In the vast majority of real use cases, ordering based on properties
 will suffice. However, in a pathological case two different variant
@@ -1208,6 +1141,8 @@ Change History
 
   - Added a non-normative guidance for installing variant wheels from
     multiple sources.
+  - Removed ``default-priorities.feature``
+    and ``default-priorities.value``.
 
 - 06-Apr-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -178,7 +178,7 @@ PEP defines the following structure:
          +- {namespace}
             +- {feature}   : list[str]  = []
 
-This structure corresponds to the version ``0.1.0`` of the format. The
+This structure corresponds to the version ``0.1.1`` of the format. The
 version number is stored as part of the schema_ URL. Whenever the format
 changes, the version number must be incremented. Tools MUST assume that
 all variant wheels using an unknown format version are unsupported.
@@ -246,7 +246,7 @@ Example
 
     {
       // The schema URL will be replaced with the final URL on packaging.python.org
-      "$schema": "https://variants-schema.wheelnext.dev/peps/825/v0.1.0.json",
+      "$schema": "https://variants-schema.wheelnext.dev/peps/825/v0.1.1.json",
 
       "default-priorities": {
         // REQUIRED: specifies that x86_64 CPU properties are more important than
@@ -319,7 +319,7 @@ like:
 
     {
       // The schema URL will be replaced with the final URL on packaging.python.org
-      "$schema": "https://variants-schema.wheelnext.dev/peps/825/v0.1.0.json",
+      "$schema": "https://variants-schema.wheelnext.dev/peps/825/v0.1.1.json",
       "default-priorities": {
         // identical to above
       },
@@ -645,7 +645,7 @@ Example
     ]
 
     [packages.variant_json]
-    "$schema" = "https://variants-schema.wheelnext.dev/peps/825/v0.1.0.json"
+    "$schema" = "https://variants-schema.wheelnext.dev/peps/825/v0.1.1.json"
 
     [packages.variant_json.default-priorities]
     namespace = [ "x86_64", "aarch64", "blas_lapack" ]

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -381,7 +381,7 @@ algorithm:
 2. For every namespace, take the ordered list of compatible feature
    names obtained previously. This is ``feature_order`` in the example.
 
-3. For every feature, take the order list of compatible values obtained
+3. For every feature, take the ordered list of compatible values obtained
    previously. This is ``value_order`` in the example.
 
 4. For every group, determine the most preferred value corresponding to

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -214,8 +214,9 @@ include updated versions of the schema. The schema is available in
 Default priorities
 ''''''''''''''''''
 
-The ``default-priorities`` dictionary defines the ordering of variants.
-The exact algorithm is described in the `Variant ordering`_ section.
+The ``default-priorities`` dictionary defines the ordering of
+namespaces which is used in variant ordering. The exact algorithm is
+described in the `Variant ordering`_ section.
 
 The following key is REQUIRED:
 

--- a/peps/pep-0825/appendix-variant-json-schema.rst
+++ b/peps/pep-0825/appendix-variant-json-schema.rst
@@ -5,7 +5,7 @@
 Appendix: JSON Schema for Variant Metadata
 ==========================================
 
-.. literalinclude:: variant-schema-0.1.0.json
+.. literalinclude:: variant-schema-0.1.1.json
    :language: json
    :linenos:
    :name: variant-json-schema

--- a/peps/pep-0825/variant-schema-0.1.1.json
+++ b/peps/pep-0825/variant-schema-0.1.1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://variants-schema.wheelnext.dev/peps/825/v0.1.0.json",
-  "title": "Variant metadata, v0.1.0",
+  "$id": "https://variants-schema.wheelnext.dev/peps/825/v0.1.1.json",
+  "title": "Variant metadata, v0.1.1",
   "description": "The format for variant metadata (variant.json) and index-level metadata ({name}-{version}-variants.json)",
   "type": "object",
   "properties": {
@@ -21,50 +21,6 @@
             "pattern": "^[a-z0-9_]+$"
           },
           "minItems": 1,
-          "uniqueItems": true
-        },
-        "feature": {
-          "description": "Default feature priorities (by namespace)",
-          "type": "object",
-          "patternProperties": {
-            "^[a-z0-9_]+$": {
-              "description": "The most preferred features",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "pattern": "^[a-z0-9_]+$"
-              },
-              "minItems": 0,
-              "uniqueItems": true
-            }
-          },
-          "additionalProperties": false,
-          "uniqueItems": true
-        },
-        "property": {
-          "description": "Default property priorities (by namespace)",
-          "type": "object",
-          "patternProperties": {
-            "^[a-z0-9_]+$": {
-              "description": "Default property priorities (by feature name)",
-              "type": "object",
-              "patternProperties": {
-                "^[a-z0-9_]+$": {
-                  "description": "The most preferred feature values",
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "pattern": "^[a-z0-9_.]+$"
-                  },
-                  "minItems": 0,
-                  "uniqueItems": true
-                }
-              },
-              "additionalProperties": false,
-              "uniqueItems": true
-            }
-          },
-          "additionalProperties": false,
           "uniqueItems": true
         }
       },


### PR DESCRIPTION
We do not really have a good use case for these, I have been leaning backwards to even provide example, the justification is limited to "completeness" and they're just adding complexity.  I think it's better to remove them before we put more effort into adding consistency requirements.