### PR TITLE
PEP 825: use semantic versioning for the schema version

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -862,6 +862,15 @@ issues because of their length, the property lists are stored inside
 the wheel and mapped to a short label that is chosen by the package
 maintainer and intended to be human-readable.
 
+Variant metadata is stored in an additional JSON format file rather than
+being added to the :doc:`packaging:specifications/core-metadata`. It is
+versioned independently, and tools that are not specifically concerned
+about variant metadata can ignore its compatibility rules. It follows
+the compatibility rules are the same as for Core Metadata. JSON provides
+a more convenient format for structured data, as well as more natural
+conversion from TOML (so that the data can be sourced from
+``pyproject.toml``).
+
 Wheel filenames alone do not provide sufficient metadata to drive
 variant wheel selection. To avoid tools having to fetch the variant
 metadata straight from multiple wheel files, the metadata from wheels

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -214,8 +214,11 @@ version number that they do not support.
 
 If a backwards compatible change is done to the specification, the minor
 version number MUST be incremented, and the patch number MUST be zeroed.
-Tools SHOULD accept metadata with a minor version number newer than the
-latest supported, provided that the major version is supported.
+Installers and other tools that only consume variant metadata SHOULD
+accept metadata with a newer minor version number than the latest
+supported, provided that the major version is supported. Tools
+outputting variant metadata MUST NOT output a version that they do not
+explicitly support.
 
 The top-level keys are described in the subsequent sections.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -866,7 +866,7 @@ Variant metadata is stored in an additional JSON format file rather than
 being added to the :doc:`packaging:specifications/core-metadata`. It is
 versioned independently, and tools that are not specifically concerned
 about variant metadata can ignore its compatibility rules. It follows
-the compatibility rules are the same as for Core Metadata. JSON provides
+the same compatibility rules as those for Core Metadata. JSON provides
 a more convenient format for structured data, as well as more natural
 conversion from TOML (so that the data can be sourced from
 ``pyproject.toml``).

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1174,6 +1174,8 @@ Change History
     multiple sources.
   - Removed ``default-priorities.feature``
     and ``default-priorities.value``.
+  - Made schema versioning use semantic versioning, with its backwards
+    compatibility impliciations.
 
 - 06-Apr-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -199,13 +199,23 @@ PEP defines the following structure:
             +- {feature}   : list[str]  = []
 
 This structure corresponds to the version ``0.1.1`` of the format. The
-version number is stored as part of the schema_ URL. Whenever the format
-changes, the version number must be incremented. Tools MUST assume that
-all variant wheels using an unknown format version are unsupported.
+version number is stored as part of the schema_ URL. The version numbers
+follow semantic versioning.
 
-The version numbers starting with zero are reserved for drafts and MUST
-NOT be used in production. Once the proposal is complete, the latest
-draft will be promoted to version ``1.0.0``.
+The numbers starting with zero are reserved for drafts and MUST NOT be
+used in production. Tools MUST NOT make any compatibility assumptions
+over these versions. Once the proposal is complete, the latest draft
+will be promoted to version ``1.0.0``.
+
+If a backwards incompatible change is done to the specification,
+the major version number MUST be incremented, and the remaining version
+components MUST be zeroed.  Tools MUST reject metadata with a major
+version number that they do not support.
+
+If a backwards compatible change is done to the specification, the minor
+version number MUST be incremented, and the patch number MUST be zeroed.
+Tools SHOULD accept metadata with a minor version number newer than the
+latest supported, provided that the major version is supported.
 
 The top-level keys are described in the subsequent sections.
 


### PR DESCRIPTION
Expand the schema versioning to strictly follow semantic versioning. That is, major versions represent breaking changes and require tools to reject incompatible versions, whereas minor versions represent backwards compatible changes and permit tools to accept them.