### PR TITLE
PEP 825: textual and consistency fixes

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -252,7 +252,9 @@ The following key is REQUIRED:
 
 - ``namespace: list[str]``: All variant namespaces used in variant
   wheels for a given package version, ordered in decreasing priority.
-  This list MUST contain all namespaces used in variant properties.
+  This list MUST contain all namespaces used in variant properties, and
+  it MUST NOT be empty: a package version providing variant wheels MUST
+  use at least one variant namespace.
 
 Default priorities are defined at the project scope. The value in
 different wheels SHOULD be identical, or one an extension of the other:

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -12,12 +12,12 @@ Author: Jonathan Dekhtiar <jonathan@dekhtiar.com>,
         Donald Stufft <donald@stufft.io>,
         Andy R. Terrel <andy.terrel@gmail.com>
 PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
-Discussions-To: https://discuss.python.org/t/pep-817-split-wheel-variants-package-format/106196
+Discussions-To: https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196
 Status: Draft
 Type: Standards Track
 Topic: Packaging
 Created: 17-Feb-2026
-Post-History: `17-Feb-2026 <https://discuss.python.org/t/pep-817-split-wheel-variants-package-format/106196>`__
+Post-History: `17-Feb-2026 <https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196>`__
 
 Abstract
 ========
@@ -76,7 +76,7 @@ Implementation requirements
 This specification is written from the perspective of file format producers.
 In the context of format definitions, the word "MUST" specifically
 indicates that the requirement must be satisfied for the data to be
-considered valid according to this specifications.
+considered valid according to this specification.
 
 Tools that produce the data formats according to this specification
 (variant wheels, the index-level metadata file) MUST always produce
@@ -254,11 +254,12 @@ The following key is REQUIRED:
   wheels for a given package version, ordered in decreasing priority.
   This list MUST contain all namespaces used in variant properties.
 
-Default priorities are defined at the project scope. Different wheels
-SHOULD use the same value. However, appending additional namespaces is
-permitted. The metadata is considered consistent if the longer list
-starts with the elements of the shorter list, in order. In this case,
-combining the metadata MUST result in the longer list being used.
+Default priorities are defined at the project scope. The value in
+different wheels SHOULD be identical, or one an extension of the other:
+additional namespaces MAY be appended. The metadata is considered
+consistent if the longer list starts with the elements of the shorter
+list, in the same order. In this case, combining the metadata MUST result
+in the longer list being used.
 
 
 Variants
@@ -270,13 +271,13 @@ that wheel and it MUST contain the label present in that wheel's
 filename.
 
 It has 3 levels. The first level keys are variant labels, the second
-level keys are namespaces, the third level are feature names, and the
-third level values are sets of feature values, converted to lists,
-sorted lexically.
+level keys are namespaces, and the third level keys are feature names.
+The third level values are sets of feature values, converted to lists
+and sorted lexically.
 
 For the metadata to be consistent, the same keys MUST always correspond
 to the same values. When combining metadata, the resulting ``variants``
-dictionary MUST be an union of all the input dictionaries.
+dictionary MUST be a union of all the input dictionaries.
 
 
 Example
@@ -335,7 +336,7 @@ as long as the values do not prevent correct operation. Tools MAY either
 use or ignore these values.
 
 This file uses the same structure as `variant metadata`_, except that
-the ``variants`` object is index-scope and it MUST list all variants
+the ``variants`` object is index-scoped and it MUST list all variants
 available on the package index for the package version in question. The
 tools MUST ensure that the variant metadata across multiple variant
 wheels of the same package version and the index-level metadata file is
@@ -610,7 +611,7 @@ The ``variant_label`` marker is a plain string:
 
     # satisfied by the variant "foobar"
     dep4; variant_label == "foobar"
-    # satisfied by any wheel other other than the null variant
+    # satisfied by any wheel other than the null variant
     # (including the non-variant wheel)
     dep5; variant_label != "null"
     # satisfied by the non-variant wheel

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1187,12 +1187,23 @@ Change History
 
 - 03-Jul-2026
 
-  - Added a non-normative guidance for installing variant wheels from
+  - Added non-normative guidance for installing variant wheels from
     multiple sources.
+  - Added an explicit "Implementation requirements" section.
+  - Clarified the scope of the individual variant metadata keys, and
+    stated the consistency requirements for each of them alongside.
+  - Added "Removing ordering information from wheel files" to rejected
+    ideas.
   - Removed ``default-priorities.feature``
-    and ``default-priorities.value``.
+    and ``default-priorities.property``.
   - Made schema versioning use semantic versioning, with its backwards
-    compatibility impliciations.
+    compatibility implications.
+
+- 11-May-2026
+
+  - Added replacing platform compatibility tags entirely to rejected
+    ideas.
+  - Clarified interpretation of sorting algorithm and index support.
 
 - 06-Apr-2026
 
@@ -1219,12 +1230,6 @@ Change History
   - Removed the variant label length limitation.
   - Changed ``pylock.toml`` integration to inline variant metadata
     rather than storing a URL and a hash.
-
-- 11-May-2026
-
-  - Added replacing platform compatibility tags entirely to rejected
-    ideas.
-  - Clarified interpretation of sorting algorithm and index support.
 
 
 Appendices

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -647,8 +647,8 @@ Proposed specification update
 The proposed text for :doc:`packaging:specifications/pylock-toml`
 follows:
 
-``[packages.variant_json]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``[packages.variants-json]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Type**: table
 - **Required?**: no
@@ -682,13 +682,13 @@ Example
         { url = "https://pypi.anaconda.org/mgorny/simple/numpy/2.3.4/numpy-2.3.4-cp314-cp314-macosx_13_0_x86_64-openblas.whl", hashes = {} },
     ]
 
-    [packages.variant_json]
+    [packages.variants-json]
     "$schema" = "https://variants-schema.wheelnext.dev/peps/825/v0.1.1.json"
 
-    [packages.variant_json.default-priorities]
+    [packages.variants-json.default-priorities]
     namespace = [ "x86_64", "aarch64", "blas_lapack" ]
 
-    [packages.variant_json.variants]
+    [packages.variants-json.variants]
     null = { }
     x86_64_v3_openblas = { "blas_lapack" = { "library" = ["openblas"]}, "x86_64" = { "level" = ["v3"]}  }
     x86_64_v4_mkl = { "blas_lapack" = { "library" = ["mkl"]}, "x86_64" = { "level" = ["v4"]}  }

--- a/peps/pep-0825/variant-schema-0.1.1.json
+++ b/peps/pep-0825/variant-schema-0.1.1.json
@@ -25,7 +25,6 @@
         }
       },
       "additionalProperties": false,
-      "uniqueItems": true,
       "required": [
         "namespace"
       ]
@@ -34,14 +33,15 @@
       "description": "Mapping of variant labels to properties",
       "type": "object",
       "patternProperties": {
-        "^[a-z0-9_.]{1,16}$": {
+        "^[a-z0-9_.]+$": {
           "type": "object",
           "description": "Mapping of namespaces in a variant",
           "patternProperties": {
-            "^[a-z0-9_.]+$": {
+            "^[a-z0-9_]+$": {
               "description": "Mapping of feature names in a namespace",
+              "type": "object",
               "patternProperties": {
-                "^[a-z0-9_.]+$": {
+                "^[a-z0-9_]+$": {
                   "description": "List of values for this variant feature",
                   "type": "array",
                   "items": {
@@ -52,16 +52,13 @@
                   "uniqueItems": true
                 }
               },
-              "uniqueItems": true,
               "additionalProperties": false
             }
           },
-          "uniqueItems": true,
           "additionalProperties": false
         }
       },
-      "additionalProperties": false,
-      "uniqueItems": true
+      "additionalProperties": false
     }
   },
   "required": [
@@ -69,6 +66,5 @@
     "default-priorities",
     "variants"
   ],
-  "additionalProperties": false,
-  "uniqueItems": true
+  "additionalProperties": false
 }


### PR DESCRIPTION
I did a detailed review, and used Claude to check for consistency between spec language, schema and non-normative text. This was the low-hanging fruit that it flagged (with manual review and tweaks). The JSON schema containing some small errors and having gone out of sync with the spec was the most fiddly thing. More detail in individual commit messages.