### PR TITLE
PEP 825: update the abstract

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -22,16 +22,17 @@ Post-History: `17-Feb-2026 <https://discuss.python.org/t/pep-825-wheel-variants-
 Abstract
 ========
 
-This PEP proposes variant wheels, an extension to
+This PEP provides the data format for variant wheels, an extension to
 :doc:`packaging:specifications/binary-distribution-format` that permits
 building multiple variants of the same package while embedding
-additional compatibility data. The specific properties are stored inside
-the wheel, and expressed via a human-readable variant label in the
-filename, which is then mapped to the actual properties via a separately
-hosted JSON mapping. This aims to make ``{tool} install {package}``
-capable of selecting the most appropriate variant of packages where
-additional compatibility dimensions such as GPU support need to be
-accounted for.
+additional compatibility data. This data is stored inside the wheel, and
+expressed via a human-readable variant label in the filename. When
+wheels are hosted on an index, it is additionally exposed in a separate
+JSON file as an optimization. It will be followed by additional PEPs
+defining the remaining aspects of variant wheels. The final aim of the
+specification is to make ``{tool} install {package}`` capable of
+selecting the most appropriate variant of packages where additional
+compatibility dimensions such as GPU support need to be accounted for.
 
 
 Motivation


### PR DESCRIPTION
The abstract was largely unchanged from PEP 817, so update it to make it clearer what the scope of this PEP is.  Avoid introducing unnecessary vocabulary while at it.