### PR TITLE
PEP 825: decouple the specification from indexes

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -406,7 +406,13 @@ Variant ordering
 This specification defines an ordering between different wheels based on
 the presence of variant metadata.
 
-For the purpose of ordering, variant properties are grouped into
+For the purpose of ordering, the combined variant metadata for all
+candidate variant wheels MUST be obtained. When installing from an
+index, this data MUST be obtained from the `index-level metadata`_ file.
+Otherwise, it MUST be obtained from the wheels directly and combined in
+the way specified in `variant metadata`_ section.
+
+Variant properties from all the eligible variant wheels are grouped into
 features, and features into namespaces. For every namespace, the tool
 MUST obtain a list of compatible features, and for every feature, a list
 of compatible values. The method of obtaining these lists will be
@@ -420,8 +426,8 @@ groups of variant wheels MUST then be ordered according to the following
 algorithm:
 
 1. Construct the ordered list of namespaces by copying the value of the
-   ``default-priorities.namespace`` key from `index-level metadata`_.
-   This is ``namespace_order`` in the example.
+   ``default-priorities.namespace`` key from the combined variant
+   metadata. This is ``namespace_order`` in the example.
 
 2. For every namespace, take the ordered list of compatible feature
    names obtained previously. This is ``feature_order`` in the example.
@@ -491,7 +497,7 @@ compatibility tags.
         ...
 
 
-    # default-priorities dict from index-level metadata
+    # default-priorities dict from combined variant metadata
     default_priorities = {
         "namespace": [...],  # : list[str]
     }

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -644,10 +644,11 @@ as wheels with different Platform compatibility tags: either all variant
 (and non-variant) wheels can be listed, or a subset of them.
 
 A new ``[packages.variants-json]`` subtable is added to the file. It
-MUST inline the contents of the `index-level metadata`_ file, converting
-the JSON structure into the respective TOML types. The ``$schema`` key
-MUST be preserved to facilitate versioning. The tools MAY remove keys
-that are not relevant to variant wheels present in ``pylock.toml``.
+MUST inline combined variant metadata, following the same format as the
+`index-level metadata`_ file, converting the JSON structure into the
+respective TOML types. The ``$schema`` key MUST be preserved to
+facilitate versioning. The tools MAY remove keys that are not relevant
+to variant wheels present in ``pylock.toml``.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.
@@ -1317,6 +1318,9 @@ Change History
 
 - 03-Jul-2026
 
+  - Decoupled most of the specification from `index-level metadata`_,
+    clarifying that it is only an optimization for scenarios where
+    wheels are published on an index.
   - Added non-normative guidance for installing variant wheels from
     multiple sources.
   - Added an explicit "Implementation requirements" section.

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -321,12 +321,15 @@ Example
 Index-level metadata
 --------------------
 
-For every package version that includes at least one variant wheel,
-there MUST exist a corresponding ``{name}-{version}-variants.json``
-file. The ``{name}`` and ``{version}`` placeholders correspond to the
-package name and version, normalized according to the same rules as
-wheel files, as found in the :ref:`packaging:wheel-file-name-spec` of
-the Binary Distribution Format specification.
+When a package version that includes at least one variant wheel is
+hosted on an index, a corresponding ``{name}-{version}-variants.json``
+file MUST be hosted as well. The purpose of the file is to optimize
+variant metadata lookups and remove the necessity of fetching multiple
+variant wheels during dependency resolution. The ``{name}`` and
+``{version}`` placeholders correspond to the package name and version,
+normalized according to the same rules as wheel files, as found in the
+:ref:`packaging:wheel-file-name-spec` of the Binary Distribution Format
+specification.
 
 The exact URL where the file is hosted is insignificant, but it MUST
 be provided in all the responses where the variant wheels are included.


### PR DESCRIPTION
As pointed out on DPO, make sure that index-level metadata file is clearly described as an optimization, and that all the remaining parts of the specification are written generically, and fit well with non-index sources.