### PR TITLE
PEP 825: specify how variant markers are evaluated

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -580,28 +580,75 @@ Environment markers
 -------------------
 
 Four new :ref:`environment markers
-<dependency-specifiers-environment-markers>` are introduced in
-dependency specifications. They all refer to the build-time properties
-of the wheel being processed, and they MUST be evaluated against the
-`variant metadata`_ rather than the environment. These are:
+<packaging:dependency-specifiers-environment-markers>` are introduced in
+dependency specifications. Unlike the markers defined by the
+:ref:`packaging:dependency-specifiers` specification, their values are
+not the same for every wheel: they are scoped to the variant properties
+that the wheel being processed was built for. They MUST be obtained as
+described in `evaluating variant markers`_. These are:
 
 1. ``variant_label``: a string, expressing the exact variant label of
    the wheel being processed. For non-variant wheels, it is an empty
    string.
 2. ``variant_properties``: a set of all
    ``namespace :: feature :: value`` tuples of the properties
-   corresponding to the variant label, as found by querying the
-   ``variants`` dictionary of variant metadata. For non-variant wheels,
-   it is an empty set.
+   corresponding to the variant label that are supported by the target
+   system. For non-variant wheels, it is an empty set.
 3. ``variant_features``: a set of all ``namespace :: feature`` pairs
    corresponding to the properties in ``variant_properties``.
 4. ``variant_namespaces``: a set of all namespaces of all the properties
    in ``variant_properties``.
 
-String markers MUST be matched using string comparison operators.
-Set markers MUST be matched via the ``in`` and ``not in`` operators.
+The ``variant_label`` marker MUST be matched using the ``==`` and
+``!=`` operators only. In particular, ``in`` and ``not in`` MUST NOT be
+used with it, as they would perform substring matching.
+
+The ``variant_properties``, ``variant_features`` and
+``variant_namespaces`` markers MUST be matched using the ``in`` and
+``not in`` operators only.
+
 Implementations MUST ignore differences in whitespace around the ``::``
 separators when matching features and properties.
+
+
+Evaluating variant markers
+''''''''''''''''''''''''''
+
+The variant markers MUST only be used in dependency specifiers, and they
+MUST NOT take part in selecting a wheel: they gate the individual
+dependency specifiers of a wheel that has already been selected. They
+MUST be evaluated only once variant wheel selection, as described in
+`variant ordering`_, has taken place.
+
+Their values MUST be determined as follows:
+
+1. ``variant_label`` is the variant label of the selected wheel, as
+   found in its filename.
+
+2. The properties that the ``variants`` dictionary of the `variant
+   metadata`_ maps to that label are taken, and expanded into
+   ``namespace :: feature :: value`` triples for every listed feature
+   value. Either the `variant metadata`_ contained in the wheel itself
+   or the `index-level metadata`_ MAY be used for this, as the
+   consistency requirements guarantee that the two agree.
+
+3. That set is filtered to the variant properties that the target system
+   supports, as already determined during variant wheel selection.
+   ``variant_properties`` is the result.
+
+4. ``variant_features`` and ``variant_namespaces`` are derived from
+   ``variant_properties``.
+
+For non-variant wheels, ``variant_label`` is an empty string and the
+three set-valued markers are empty sets. No variant metadata is needed
+in order to evaluate variant markers for such wheels.
+
+
+Example
+'''''''
+
+The following dependency specifiers illustrate the four markers and the
+operators permitted with each of them:
 
 .. code::
 
@@ -619,7 +666,23 @@ separators when matching features and properties.
     # satisfied only by "foo :: bar :: baz" property
     dep6; "foo :: bar :: baz" in variant_properties
     # equivalent
-    dep6; "foo::bar::baz" in variant_properties
+    dep7; "foo::bar::baz" in variant_properties
+
+The filtering in step 3. is only observable where a variant feature
+lists multiple values, of which the target system needs to support just
+one (see `variant properties`_). Consider a wheel whose properties
+include both of:
+
+.. code:: text
+
+    nvidia :: sm_arch :: 120_real
+    nvidia :: sm_arch :: 110_real
+
+On a system that provides both architectures, ``variant_properties``
+contains both properties. On a system that provides only the former, it
+contains ``nvidia :: sm_arch :: 120_real`` alone, and a dependency
+specifier testing for ``nvidia :: sm_arch :: 110_real`` is therefore not
+satisfied.
 
 
 Integration with pylock.toml
@@ -724,13 +787,14 @@ behavior would be to:
 9. If multiple wheels for a given version share the same variant label,
    order them by Platform compatibility tags and build number, and
    select the best wheel.
-10. Process the `environment markers`_ in wheel dependencies using
-    the label of the selected variant wheels and the full set of variant
-    properties corresponding to it in the wheel metadata.
+10. Read the dependencies of the selected wheel, and evaluate the
+    `environment markers`_ occurring in them, using the label of the
+    selected wheel and those of its variant properties that the target
+    system supports, as described in `evaluating variant markers`_.
 
 Note that steps 4. through 8. are introduced specifically for variant
 wheels. The remaining steps correspond to the current installer
-behavior.  Step 10. is modified through the presence of new environment
+behavior. Step 10. is modified through the presence of new environment
 markers.
 
 When installing from a source that does not provide an `index-level
@@ -752,9 +816,10 @@ to:
 4. Obtain the ordered lists of compatible variant properties. The
    mechanism for this will be specified in a subsequent PEP.
 5. Verify the wheel compatibility via compatible properties.
-6. Process the `environment markers`_ in wheel dependencies using
-   the label of the selected variant wheels and the full set of variant
-   properties corresponding to it in the wheel metadata.
+6. Read the dependencies of the wheel, and evaluate the `environment
+   markers`_ occurring in them, using the label of the wheel and those
+   of its variant properties that the target system supports, as
+   described in `evaluating variant markers`_.
 
 
 Publishing variant wheels on an index
@@ -1076,6 +1141,64 @@ due to the variant metadata being updated or being generated in a way
 that does not guarantee stable bytewise output.
 
 
+Variant environment markers
+---------------------------
+
+Variant properties take part in installing a variant wheel at two
+distinct points, and only the second of them concerns markers. An
+installer first selects a package version, filters the wheels for that
+version by Platform compatibility tags, and then filters and orders the
+remaining variant wheels using their variant properties, checked against
+the properties that the target system supports; tools may override the
+resulting choice. Only afterwards are the dependencies of the selected
+wheel read, and the variant markers occurring in them evaluated.
+
+Filtering and ordering wheels is therefore driven by variant properties,
+not by markers. Markers never gate the selection of a wheel; they only
+gate individual dependency specifiers, and they are evaluated only once
+a wheel has been selected. Were it otherwise, a marker would have to be
+evaluated before the wheel whose properties it refers to was known.
+
+The values of the three set-valued markers are filtered to the variant
+properties that the target system supports. Without that step, a wheel
+would pull in the dependencies of every value a variant feature lists,
+rather than those of the value that is actually in use.
+
+Because of this filtering, the variant markers do not depart from the
+established meaning of an environment marker. Every property in
+``variant_properties`` is by construction supported by the target
+system, so the three set-valued markers describe the environment, just
+as the markers defined in :ref:`packaging:dependency-specifiers` do.
+What is specific to variant wheels is the vocabulary rather than the
+semantics. The existing markers expose a fixed set of environment
+attributes to every wheel alike, whereas a variant property has to be
+declared by the wheel before it can be observed at all: the wheel's
+`variant metadata`_ determines which part of the environment its
+dependency specifiers are able to see. ``variant_label`` is the
+exception, as it names the selected variant and says nothing about the
+environment beyond the fact that this variant was deemed compatible.
+
+Three consequences of this design are worth noting:
+
+- Filtering never removes an entire feature or namespace from a wheel
+  that the target system supports, since such a wheel has at least one
+  supported value for every feature it declares (see `variant
+  properties`_). For those wheels, ``variant_features`` and
+  ``variant_namespaces`` list every feature and namespace that the wheel
+  was built for.
+
+- For the null variant, ``variant_label`` is ``"null"`` and the three
+  set-valued markers are empty sets, as the null variant has zero
+  properties. ``variant_label`` is consequently the only marker that
+  distinguishes a null variant from a non-variant wheel.
+
+- A marker referring to a property, feature or namespace that the wheel
+  does not declare cannot be satisfied in any environment, since
+  filtering only ever removes properties. Such markers can therefore be
+  resolved at build time, which is what makes the partial evaluation
+  described in `Backwards Compatibility`_ possible.
+
+
 Backwards Compatibility
 =======================
 
@@ -1293,9 +1416,17 @@ The following problems are deferred to subsequent PEPs in the series:
 Open Issues
 ===========
 
-- There is an open discussion whether using `environment markers`_ are
-  the right mechanism to express dependencies that are present in a
-  subset of variant wheels.
+These questions must be resolved before this PEP can be accepted.
+
+Use of variant environment markers
+----------------------------------
+
+The design of the variant `environment markers`_ is not yet settled. The same
+effect can be achieved through Dynamic dependencies; the open question is
+whether markers are the right mechanism for obtaining it while keeping
+dependency metadata static across a release. This is under discussion in
+`this thread <https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196/169>`__.
+The specification reflects the current design.
 
 
 Acknowledgements

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -592,20 +592,18 @@ described in `evaluating variant markers`_. These are:
    string.
 2. ``variant_properties``: a set of all
    ``namespace :: feature :: value`` tuples of the properties
-   corresponding to the variant label that are supported by the target
+   corresponding to the variant label that are compatible with the target
    system. For non-variant wheels, it is an empty set.
 3. ``variant_features``: a set of all ``namespace :: feature`` pairs
    corresponding to the properties in ``variant_properties``.
 4. ``variant_namespaces``: a set of all namespaces of all the properties
    in ``variant_properties``.
 
-The ``variant_label`` marker MUST be matched using the ``==`` and
-``!=`` operators only. In particular, ``in`` and ``not in`` MUST NOT be
-used with it, as they would perform substring matching.
-
-The ``variant_properties``, ``variant_features`` and
-``variant_namespaces`` markers MUST be matched using the ``in`` and
-``not in`` operators only.
+``variant_label`` is a ``String`` field, while ``variant_properties``,
+``variant_features`` and ``variant_namespaces`` are ``Set of String``
+fields. The operators available for each, and their semantics, are those
+defined for the respective field types in
+:ref:`packaging:dependency-specifiers`.
 
 Implementations MUST ignore differences in whitespace around the ``::``
 separators when matching features and properties.


### PR DESCRIPTION
The additions to Specification are as discussed on DPO. The Rationale additions aim to answer all the concerns and misunderstandings we've seen in discussions of the design of variant environment markers.

The specification rewrite of the existing content on markers in the previous commit was an improvement, this only adds a few textual tweaks where I thought there could still be ambiguity.