### PR TITLE
PEP 825: finish decoupling the spec from the index-level file

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1379,17 +1379,14 @@ within ``pyproject.toml`` file) and to be copied into every variant
 wheel at build time, and afterwards into the `index-level metadata`_
 file.
 
-On the discussion thread concerning this PEP, `an extensive argument
-regarding the data model was made
-<https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196/111>`__.
-Essentially, the argument was that this data becomes a wheel-level
-property that, when inserted in a particular wheel, is saying something
-about "other wheels". We do not believe this is the case. Rather, the
-data is project-level metadata which is copied into the wheel.
-Similarly to other project metadata, there is no reference to other
-wheels. For example, the ordering data can specify namespaces for which
-no variant wheels exist in a particular release; nothing in the format
-depends on the presence of specific other wheels.
+It has been argued that this makes the ordering data a wheel-level
+property which, once inserted into a particular wheel, says something
+about other wheels. That is not the case. The data is project-level
+metadata that is copied into the wheel, and like the other project
+metadata carried there, it does not reference other wheels. The ordering
+data can specify namespaces for which no variant wheels exist in a
+particular release, and nothing in the format depends on the presence of
+any specific other wheel.
 
 Furthermore, this design specifically ensures that the index-level
 metadata file is a cache rather than a first-order data source. Since
@@ -1406,18 +1403,14 @@ all the data is stored in the wheels:
 
 There is indeed a real risk that two wheels built at different times
 and with different tooling may end up having inconsistent metadata.
-However, the PEP specifically requires consistency, and expects the
-tools to verify it. Furthermore, the problem is more general; such a
-build scenario could lead to any other duplicated part of Core Metadata
-being inconsistent across wheels and causing unexpected behavior in
-tools.
+However, the specification requires consistency, and states how tools
+are expected to respond where it does not hold.
 
-The post also makes a claim that detaching the ordering data from
-variant metadata makes it possible for tools to accept an override of
-the ordering data in a standard format. However, there is no relation
-between that and the presence of ordering data in variant metadata; such
-a format can be introduced either way (for example, using the subset of
-variant metadata).
+It has also been suggested that detaching the ordering data from variant
+metadata would make it possible for tools to accept an override of that
+data in a standard format. However, there is no relation between the
+two; such a format can be introduced either way, for example using a
+subset of variant metadata.
 
 
 Out of scope

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -92,8 +92,7 @@ ecosystem, such as a package index accepting an upload, SHOULD do so.
 Tools that encounter it later, such as an installer resolving a
 dependency, SHOULD prefer to degrade gracefully rather than fail
 outright, for example by ignoring the variant wheels and selecting among
-the remaining ones. A single malformed wheel should not render an entire
-package version uninstallable.
+the remaining ones.
 
 
 Variant wheel
@@ -822,8 +821,8 @@ The same algorithm applies to sources other than an index, such as a
 local directory of wheels.
 
 
-Installing a local wheel
-''''''''''''''''''''''''
+Installing a specific local wheel
+'''''''''''''''''''''''''''''''''
 
 When asked to install a local wheel file, the proposed behavior would be
 to:

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -84,11 +84,16 @@ Tools that produce the data formats according to this specification
 files that meet the requirements of this specification.
 
 Tools that consume the data formats according to this specification
-SHOULD refuse to process the files that do not meet these requirements.
-In this case, it is recommended to follow the same behavior as for
-invalid Core Metadata in wheel files. For example, a wheel index may
-reject the upload, while a package manager may skip the version
-entirely.
+SHOULD NOT rely on data that does not meet these requirements. The
+appropriate response depends on the role of the tool, and follows the
+same pattern as for invalid Core Metadata in wheel files. Tools that are
+in a position to reject invalid data at the point it enters the
+ecosystem, such as a package index accepting an upload, SHOULD do so.
+Tools that encounter it later, such as an installer resolving a
+dependency, SHOULD prefer to degrade gracefully rather than fail
+outright, for example by ignoring the variant wheels and selecting among
+the remaining ones. A single malformed wheel should not render an entire
+package version uninstallable.
 
 
 Variant wheel
@@ -407,10 +412,12 @@ This specification defines an ordering between different wheels based on
 the presence of variant metadata.
 
 For the purpose of ordering, the combined variant metadata for all
-candidate variant wheels MUST be obtained. When installing from an
-index, this data MUST be obtained from the `index-level metadata`_ file.
-Otherwise, it MUST be obtained from the wheels directly and combined in
-the way specified in `variant metadata`_ section.
+candidate variant wheels MUST be obtained. It can be sourced either from
+the `index-level metadata`_ file, or from the individual wheels,
+combined as specified in the `variant metadata`_ section. Both sources
+yield the same result, since they are required to be consistent, and
+tools SHOULD prefer the index-level metadata file where it is available,
+as obtaining the data from it is considerably cheaper.
 
 Variant properties from all the eligible variant wheels are grouped into
 features, and features into namespaces. For every namespace, the tool
@@ -779,14 +786,19 @@ behavior would be to:
 3. Filter available wheels based on Platform Compatibility Tags.
 4. Determine if any of the remaining wheels are variant wheels.
    If not, proceed as with non-variant wheels.
-5. If any wheels feature a `variant label`_, download the `index-level
-   metadata`_ file, ``{name}-{version}-variants.json``. If this
-   file is missing, assume all variant wheels are incompatible and
-   proceed as with non-variant wheels.
+5. If any wheels feature a `variant label`_, obtain the combined variant
+   metadata. Normally this means downloading the `index-level
+   metadata`_ file, ``{name}-{version}-variants.json``. If the source
+   does not provide that file, the combined metadata can instead be read
+   from the candidate wheels. Only one wheel per distinct variant label
+   needs to be inspected, and only the `variant metadata`_ file within
+   it, rather than the whole wheel. Where this is still too expensive, a
+   tool may treat the variant wheels as incompatible and proceed with
+   the non-variant wheels instead.
 6. Map the variant labels into sets of variant properties using the
-   index-level variant metadata file. If any of the labels present in
-   wheel filenames are missing in the file, assume that the respective
-   wheels are incompatible.
+   combined variant metadata. If any of the labels present in wheel
+   filenames are missing from it, assume that the respective wheels are
+   incompatible.
 7. Obtain the ordered lists of compatible variant properties. The
    mechanism for this will be specified in a subsequent PEP.
 8. Filter and order variants based on the lists of compatible
@@ -806,9 +818,8 @@ wheels. The remaining steps correspond to the current installer
 behavior. Step 10. is modified through the presence of new environment
 markers.
 
-When installing from a source that does not provide an `index-level
-metadata`_, the same algorithm can be used, except that the variant
-metadata needs to be read directly from the wheels.
+The same algorithm applies to sources other than an index, such as a
+local directory of wheels.
 
 
 Installing a local wheel
@@ -844,17 +855,11 @@ If the index is responsible for generating the file, it should use some
 mechanism to defer publishing it until the release is fully uploaded
 (for example, :pep:`694`).
 
-To generate the ``{name}-{version}-variants.json`` file:
-
-1. For the first variant wheel for a given package version, copy the
-   data from its ``*.dist-info/variant.json`` file.
-2. For subsequent wheels, merge the data from their
-   ``*.dist-info/variant.json`` files into the existing data:
-
-   - disjoint keys of ``variants`` dictionary are merged together
-   - common keys of these dictionaries must have exactly the same value
-   - ``default-priorities.namespace`` list can be replaced if the new
-     value starts with the old value
+To generate the ``{name}-{version}-variants.json`` file, take the
+``*.dist-info/variant.json`` files of all the variant wheels for a given
+package version and combine them, as specified for the individual keys
+in the `default priorities`_ and `variants`_ sections. The result does
+not depend on the order in which the wheels are processed.
 
 
 Installation example (non-normative)
@@ -982,13 +987,17 @@ As of the time of writing, there are no accepted standards addressing
 the support for installing packages from multiple sources, and the
 existing tools (such as ``pip`` and ``uv``) disagree on the exact
 behavior. This problem is described in more detail in the informational
-:pep:`766`. Variant wheels expand the problem scope, as the variant
-metadata that influences the selection among multiple wheels is scoped
-at index level, and therefore the metadata acquired from different
-indexes cannot be compared or combined in a meaningful way. For these
-reasons, the specification does not attempt to standardize a behavior,
-but instead considers it implementation-defined and provides a few
-non-normative suggestions on the possible solutions.
+:pep:`766`. Variant wheels expand the problem scope. The consistency
+requirements that make variant metadata combinable hold within a single
+project, and nothing obliges independent publishers to meet them with
+respect to one another: the same variant label may map to different
+properties, and namespace orderings chosen independently need not be
+extensions of one another. Establishing whether the metadata from two
+sources happens to be combinable is possible, but the cost of doing so
+in the general case is prohibitive, and there is no correct answer when
+it is not. For these reasons, the specification does not attempt to
+standardize a behavior, but instead considers it implementation-defined
+and provides a few non-normative suggestions on the possible solutions.
 
 It is entirely valid for tools not to support this behavior, either by
 not providing support for using multiple sources at all, or by rejecting
@@ -1475,6 +1484,7 @@ Change History
   - Made ``variant_properties`` environment marker use variant
     properties compatible with the system rather than all the properties
     specified in the metadata.
+  - Various smaller fixes for language and design consistency.
 
 - 11-May-2026
 


### PR DESCRIPTION
Follow-up to PR gh-72, which describes the index-level metadata file as an optimization. Several sections still assumed it was the authoritative source.

Variant ordering no longer requires the index-level file. The combined metadata may be sourced from it or from the wheels; both are required to agree, and tools SHOULD prefer the file where available because it is cheaper. This also removes the need to say what "installing from an index" means, which was never defined and which the Rationale straddles by counting a webserver directory listing as an index.

The suggested implementation logic gave two answers for a missing file: step 5 treated the variant wheels as incompatible, while the paragraph below it said to read the metadata from the wheels. Keep the latter, and make it clear that the cost is not as high as one might think at first (because previous filtering).
Also make declining an option. The section is non-normative, and a tool that finds the remaining cost unacceptable may treat the variant wheels as incompatible instead. The case the Rejected Ideas argument rests on is installing from a local directory, where the wheels are already present and the fallback costs nothing.

Publishing no longer restates the merge rules (the description had drifted).

The multi-source section justified leaving behavior undefined on the grounds that the metadata is scoped at index level - and we decoupled that.

Finally, split the response to invalid data by the role of the tool. Requiring consumers to refuse it meant an installer skipping a version outright, so one malformed wheel could act as a de facto yank for every user. Indexes should reject at upload; installers should degrade.