### PR TITLE
PEP 825: make the rejected idea read standalone

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1370,17 +1370,14 @@ within ``pyproject.toml`` file) and to be copied into every variant
 wheel at build time, and afterwards into the `index-level metadata`_
 file.
 
-On the discussion thread concerning this PEP, `an extensive argument
-regarding the data model was made
-<https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196/111>`__.
-Essentially, the argument was that this data becomes a wheel-level
-property that, when inserted in a particular wheel, is saying something
-about "other wheels". We do not believe this is the case. Rather, the
-data is project-level metadata which is copied into the wheel.
-Similarly to other project metadata, there is no reference to other
-wheels. For example, the ordering data can specify namespaces for which
-no variant wheels exist in a particular release; nothing in the format
-depends on the presence of specific other wheels.
+It has been argued that this makes the ordering data a wheel-level
+property which, once inserted into a particular wheel, says something
+about other wheels. That is not the case. The data is project-level
+metadata that is copied into the wheel, and like the other project
+metadata carried there, it does not reference other wheels. The ordering
+data can specify namespaces for which no variant wheels exist in a
+particular release, and nothing in the format depends on the presence of
+any specific other wheel.
 
 Furthermore, this design specifically ensures that the index-level
 metadata file is a cache rather than a first-order data source. Since
@@ -1397,18 +1394,14 @@ all the data is stored in the wheels:
 
 There is indeed a real risk that two wheels built at different times
 and with different tooling may end up having inconsistent metadata.
-However, the PEP specifically requires consistency, and expects the
-tools to verify it. Furthermore, the problem is more general; such a
-build scenario could lead to any other duplicated part of Core Metadata
-being inconsistent across wheels and causing unexpected behavior in
-tools.
+However, the specification requires consistency, and states how tools
+are expected to respond where it does not hold.
 
-The post also makes a claim that detaching the ordering data from
-variant metadata makes it possible for tools to accept an override of
-the ordering data in a standard format. However, there is no relation
-between that and the presence of ordering data in variant metadata; such
-a format can be introduced either way (for example, using the subset of
-variant metadata).
+It has also been suggested that detaching the ordering data from variant
+metadata would make it possible for tools to accept an override of that
+data in a standard format. However, there is no relation between the
+two; such a format can be introduced either way, for example using a
+subset of variant metadata.
 
 
 Out of scope


### PR DESCRIPTION
This is a follow-up to gh-60. Two changes to "Removing ordering information from wheel files":

- Avoid a link to a specific post (this was my suggestion, changed my mind - apologies)
- Reduce the length of that section; acknowledge there is a risk. We will address this by the overall argument for metadata consistency that is still to come.