### PR TITLE
PEP 825: gather the consistency requirements into one section

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -343,10 +343,9 @@ use or ignore these values.
 
 This file uses the same structure as `variant metadata`_, except that
 the ``variants`` object is index-scoped and it MUST list all variants
-available on the package index for the package version in question. The
-tools MUST ensure that the variant metadata across multiple variant
-wheels of the same package version and the index-level metadata file is
-consistent, as defined in sections corresponding to the specific keys.
+available on the package index for the package version in question. It
+MUST be consistent with the `variant metadata`_ of the individual
+wheels, as specified in `metadata consistency`_.
 
 This file SHOULD NOT be considered immutable and MAY be updated in a
 backward compatible way at any point (e.g. when adding a new variant).
@@ -398,6 +397,46 @@ like:
         }
       }
     }
+
+
+Metadata consistency
+--------------------
+
+The `variant metadata`_ carried by the individual variant wheels of a
+package version, and the `index-level metadata`_ file where one is
+published, all describe the same release, and are required to agree with
+one another. Gathered in one place, and stated in full in the sections
+defining the respective keys, the requirements are:
+
+- ``default-priorities.namespace``: the lists MUST either be identical,
+  or the longer MUST start with the elements of the shorter one, in the
+  same order. Combining them MUST yield the longer list.
+
+- ``variants``: a variant label occurring in more than one of them MUST
+  map to the same properties in each. Combining them MUST yield the
+  union of the dictionaries.
+
+Both rules are symmetric, so combining metadata that satisfies them
+gives the same result regardless of the order in which the inputs are
+processed.
+
+Meeting these requirements is the responsibility of the publisher of the
+package version. Since the data originates from a single source per
+project and is copied into the wheels at build time, they are satisfied
+by construction unless the wheels of one release are built from
+different inputs.
+
+Tools consuming variant metadata MAY assume that these requirements are
+met. This specification does not require them to verify it, and does not
+prescribe what they do if they detect that it does not hold.
+
+Where a user draws wheels for the same package from more than one
+source, no publisher is in a position to guarantee consistency with the
+others. Ensuring that the sources being combined are consistent is then
+the responsibility of the user. Tools are not required to detect or
+resolve inconsistencies between sources; `installing wheels from
+multiple sources (non-normative)`_ discusses what they can reasonably do
+instead.
 
 
 Variant ordering

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -412,8 +412,8 @@ defining the respective keys, the requirements are:
   or the longer MUST start with the elements of the shorter one, in the
   same order. Combining them MUST yield the longer list.
 
-- ``variants``: a variant label occurring in more than one of them MUST
-  map to the same properties in each. Combining them MUST yield the
+- ``variants``: the same variant label MUST always map to the same set
+  of properties. Combining them MUST yield the
   union of the dictionaries.
 
 Both rules are symmetric, so combining metadata that satisfies them

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -413,8 +413,7 @@ defining the respective keys, the requirements are:
   same order. Combining them MUST yield the longer list.
 
 - ``variants``: the same variant label MUST always map to the same set
-  of properties. Combining them MUST yield the
-  union of the dictionaries.
+  of properties. Combining them MUST yield the union of the dictionaries.
 
 Both rules are symmetric, so combining metadata that satisfies them
 gives the same result regardless of the order in which the inputs are


### PR DESCRIPTION
Paul asked for this new section, and it's actually helpful to have a section titled "Metadata consistency" I think. It shows there aren't that many requirements, and explains it's auto-fulfilled when building from a single source.

Also one small fix in the "Index-level metadata" section.