### PR TITLE
PEP 825: more consistency fixes, update pylock section for env markers, more precise selection overrides

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -750,11 +750,25 @@ A new ``[packages.variants-json]`` subtable is added to the file. It
 MUST inline combined variant metadata, following the same format as the
 `index-level metadata`_ file, converting the JSON structure into the
 respective TOML types. The ``$schema`` key MUST be preserved to
-facilitate versioning. The tools MAY remove keys that are not relevant
-to variant wheels present in ``pylock.toml``.
+facilitate versioning. The tools MAY remove the entries of the
+``variants`` dictionary whose labels do not occur among the wheels
+listed for the package, along with any namespaces that are thereby left
+unused in ``default-priorities.namespace``. The entry for every label
+that does occur MUST be retained in full, as `evaluating variant
+markers`_ requires the complete set of properties corresponding to the
+selected label.
 
 If variant wheels are listed, the tool SHOULD resolve variants to select
 the best wheel file.
+
+Variant `environment markers`_ occurring in the dependency specifiers of
+a locked package are evaluated in the context of the wheel selected for
+that package's entry, as described in `evaluating variant markers`_. No
+further context is needed in the lock file: the markers are evaluated
+only once that wheel has been selected, and every package entry resolves
+its own wheel. Since variant markers may only be used in dependency
+specifiers, they cannot occur in ``packages.marker`` or in the top-level
+``environments`` key, neither of which is scoped to a selected wheel.
 
 
 Proposed specification update
@@ -1514,9 +1528,10 @@ Change History
     and ``default-priorities.property``.
   - Made schema versioning use semantic versioning, with its backwards
     compatibility implications.
-  - Made ``variant_properties`` environment marker use variant
-    properties compatible with the system rather than all the properties
-    specified in the metadata.
+  - Improve environment marker content. Make ``variant_properties``
+    marker use variant properties compatible with the system rather
+    than all the properties specified in the metadata.
+  - Update pylock.toml section to explain environment marker usage.
   - Various smaller fixes for language and design consistency.
 
 - 11-May-2026

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -214,7 +214,7 @@ will be promoted to version ``1.0.0``.
 
 If a backwards incompatible change is done to the specification,
 the major version number MUST be incremented, and the remaining version
-components MUST be zeroed.  Tools MUST reject metadata with a major
+components MUST be zeroed. Tools MUST reject metadata with a major
 version number that they do not support.
 
 If a backwards compatible change is done to the specification, the minor
@@ -274,8 +274,8 @@ Variants
 
 The ``variants`` dictionary provides a mapping from variant labels
 to variant properties. In an individual variant wheel, it is scoped to
-that wheel and it MUST contain the label present in that wheel's
-filename.
+that wheel and it MUST contain exactly one entry, whose key is the
+variant label present in that wheel's filename.
 
 It has 3 levels. The first level keys are variant labels, the second
 level keys are namespaces, and the third level keys are feature names.
@@ -1113,8 +1113,8 @@ maintainer and intended to be human-readable.
 Variant metadata is stored in an additional JSON format file rather than
 being added to the :doc:`packaging:specifications/core-metadata`. It is
 versioned independently, and tools that are not specifically concerned
-about variant metadata can ignore its compatibility rules. It follows
-the same compatibility rules as those for Core Metadata. JSON provides
+about variant metadata can ignore its compatibility rules. Its
+versioning is similar in spirit to that of Core Metadata. JSON provides
 a more convenient format for structured data, as well as more natural
 conversion from TOML (so that the data can be sourced from
 ``pyproject.toml``).
@@ -1495,7 +1495,7 @@ and Zanie Blue.
 Change History
 ==============
 
-- 03-Jul-2026
+- 08-Aug-2026
 
   - Decoupled most of the specification from `index-level metadata`_,
     clarifying that it is only an optimization for scenarios where

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -83,11 +83,12 @@ Tools that produce the data formats according to this specification
 (variant wheels, the index-level metadata file) MUST always produce
 files that meet the requirements of this specification.
 
-Tools that consume the data formats according to this specification
-SHOULD NOT rely on data that does not meet these requirements. The
-appropriate response depends on the role of the tool, and follows the
-same pattern as for invalid Core Metadata in wheel files. Tools that are
-in a position to reject invalid data at the point it enters the
+Tools that consume the data formats according to this specification are
+not required to verify that the data meets these requirements, but
+SHOULD NOT rely on data that they have established does not meet them.
+The appropriate response depends on the role of the tool, and follows
+the same pattern as for invalid Core Metadata in wheel files. Tools that
+are in a position to reject invalid data at the point it enters the
 ecosystem, such as a package index accepting an upload, SHOULD do so.
 Tools that encounter it later, such as an installer resolving a
 dependency, SHOULD prefer to degrade gracefully rather than fail
@@ -430,8 +431,9 @@ by construction unless the wheels of one release are built from
 different inputs.
 
 Tools consuming variant metadata MAY assume that these requirements are
-met. This specification does not require them to verify it, and does not
-prescribe what they do if they detect that it does not hold.
+met, and are not required to verify it. Where a tool does establish that
+they are not met, the response described in `implementation
+requirements`_ applies.
 
 Where a user draws wheels for the same package from more than one
 source, no publisher is in a position to guarantee consistency with the
@@ -1440,8 +1442,9 @@ all the data is stored in the wheels:
 
 There is indeed a real risk that two wheels built at different times
 and with different tooling may end up having inconsistent metadata.
-However, the specification requires consistency, and states how tools
-are expected to respond where it does not hold.
+However, the specification requires consistency and makes the publisher
+of the package version responsible for it, as described in `metadata
+consistency`_.
 
 It has also been suggested that detaching the ordering data from variant
 metadata would make it possible for tools to accept an override of that

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -521,7 +521,13 @@ sorted from the most preferred to the least preferred.
 The tools MAY provide options to override the default ordering, for
 example by specifying a preference for specific namespaces, features
 or properties. The tools MAY also provide options to exclude specific
-variants, or to select a particular variant.
+variants, or to select a particular variant. These options operate on
+the wheels that were found compatible, so they MAY reorder or narrow
+that set, but MUST NOT cause a wheel to be selected whose properties
+the target system does not support. Installing a variant wheel for a
+system other than the one being installed to is instead a matter of
+overriding which properties are considered supported, which is `out of
+scope`_ for this PEP.
 
 Alternatively, the sort algorithm for variant wheels could be described
 using the following pseudocode. For simplicity, this code does not
@@ -688,7 +694,10 @@ Their values MUST be determined as follows:
 
 3. That set is filtered to the variant properties that the target system
    supports, as already determined during variant wheel selection.
-   ``variant_properties`` is the result.
+   ``variant_properties`` is the result. Since a wheel can only be
+   selected if the target system supports it, and that requires at least
+   one supported value for every feature the wheel declares, this step
+   never removes a feature entirely.
 
 4. ``variant_features`` and ``variant_namespaces`` are derived from
    ``variant_properties``.
@@ -1026,9 +1035,10 @@ When a package manager is requested to install ``torch``, in order:
    the tag.
 
 7. The metadata for the selected wheel is processed. The variant
-   properties corresponding to the wheel (as stored in the ``variants``
-   dictionary) are used to process `environment markers`_. This results
-   in additional CUDA-related dependencies being selected.
+   properties corresponding to the wheel, narrowed to those the system
+   was found to support in step 4, are used to process `environment
+   markers`_. This results in additional CUDA-related dependencies being
+   selected.
 
 8. The wheel is downloaded and installed.
 
@@ -1251,12 +1261,15 @@ environment beyond the fact that this variant was deemed compatible.
 
 Three consequences of this design are worth noting:
 
-- Filtering never removes an entire feature or namespace from a wheel
-  that the target system supports, since such a wheel has at least one
-  supported value for every feature it declares (see `variant
-  properties`_). For those wheels, ``variant_features`` and
-  ``variant_namespaces`` list every feature and namespace that the wheel
-  was built for.
+- Filtering never removes an entire feature or namespace, since a wheel
+  can only be selected if the target system supports at least one value
+  for every feature it declares (see `variant properties`_).
+  ``variant_features`` and ``variant_namespaces`` therefore always list
+  every feature and namespace the wheel was built for. This is why the
+  overrides permitted in `variant ordering`_ may not reach past the
+  compatibility filter: a wheel selected in spite of being unsupported
+  could have its properties filtered away, and the dependencies gated on
+  them would silently disappear.
 
 - For the null variant, ``variant_label`` is ``"null"`` and the three
   set-valued markers are empty sets, as the null variant has zero


### PR DESCRIPTION
The first three commits are probably straightforward to understand - more detail in commit messages. Explaining environment markers within `pylock.toml` was just missing.

The last commit about overrides is a little more tricky, and it was already asked about on DPO (e.g., https://discuss.python.org/t/pep-825-wheel-variants-package-format-split-from-pep-817/106196/167). The problem with overrides was that they can't be applied in combination with the filtering step of environment markers, _unless_ the override is just a selection for already-valid wheels for the target environment. So make that explicit.