### PR TITLE
PEP 825: show why the marker values are filtered/narrowed

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1040,6 +1040,17 @@ When a package manager is requested to install ``torch``, in order:
    markers`_. This results in additional CUDA-related dependencies being
    selected.
 
+   Suppose the wheel also depends on a library that supports only one
+   of the architectures it runs on:
+
+   .. code:: text
+
+       fast-gemm; "nvidia :: sm_arch :: 120_real" in variant_properties
+
+   On a system with an older GPU, ``120_real`` is not among the
+   supported properties found in step 4, so the narrowing removes it and
+   this dependency is not selected.
+
 8. The wheel is downloaded and installed.
 
 
@@ -1241,9 +1252,15 @@ a wheel has been selected. Were it otherwise, a marker would have to be
 evaluated before the wheel whose properties it refers to was known.
 
 The values of the three set-valued markers are filtered to the variant
-properties that the target system supports. Without that step, a wheel
-would pull in the dependencies of every value a variant feature lists,
-rather than those of the value that is actually in use.
+properties that the target system supports. A wheel lists every value it
+runs on, so without that step a dependency gated on one of them would be
+installed wherever the wheel runs. A wheel built for GPU architectures
+from ``80_real`` to ``120_real`` may depend on a library that supports
+only ``120_real``, much as a dependency that supports a single CPU
+architecture is gated on ``platform_machine``. Where a dependency does
+exist for every value of a feature, it can instead be published as a
+variant package and depended upon unconditionally, leaving the choice to
+`variant ordering`_.
 
 Because of this filtering, the variant markers do not depart from the
 established meaning of an environment marker. Every property in

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1041,7 +1041,7 @@ When a package manager is requested to install ``torch``, in order:
    selected.
 
    Suppose the wheel also depends on a library that supports only one
-   of the architectures it runs on:
+   of the architectures the wheel supports:
 
    .. code:: text
 


### PR DESCRIPTION
The Rationale said only that without narrowing a wheel "would pull in the dependencies of every value a variant feature lists", which states the mechanism without giving a reader anything to picture, and the installation example illustrated a case where narrowing changes nothing observable. Between them the step looked like complexity with no purpose.

Address that by:

- Explicitly naming the main use case it exists for.
- Note also when the alternative (the dependency also publishing variants) applies.

There may be other reasons, like "my dependency has a bug for specific hardware". Those reasons also occur for other environment markers. However, that would make the text even longer - one example should suffice. In the end, the ability to treat GPU hardware like CPU families (selection-wise) is what matters.