### PR TITLE
PEP 825: provide a high-level ordering overview and clarify

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -501,22 +501,52 @@ preferred wheel. This is similar to how Python orders lists and tuples:
 it compares corresponding elements from first to last until it finds an
 unequal pair or one sequence runs out of elements.
 
-To express it with Python types instead: Each variant wheel has a set of
-3-tuples, its variant properties. Take the compatible wheels and filter
-their property sets to those compatible with the system as well as values
-that are not the best value in their feature. Sort the remaining set entries
-into an (ordered) list, more preferred properties sorted higher.
-Now you can the sort the wheels by comparing their lists with Python list
-order semantics, except for using a sort key that use variant property
-ordering over lexicographic ordering for the tuples inside the list. The
-wheel sorted to the top is the most preferred wheel.
+As an example, take four variant wheels of a package that ranks the
+``nvidia`` namespace above ``x86_64``:
 
-As an example, take a GPU wheel with ``nvidia`` properties and an
-optimized CPU wheel with ``x86_64`` properties, where the package ranks
-``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
-carry the same CUDA properties, the comparison moves to their next
-triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
-``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
+.. code:: python
+
+    # Rankings, most preferred first. The namespace ranking comes from
+    # the package's variant metadata; the feature and value rankings
+    # will be defined in a subsequent PEP.
+    namespaces = ["nvidia", "x86_64"]
+    features = {"nvidia": ["cuda_version_lower_bound"], "x86_64": ["level"]}
+    values = {
+        "nvidia": {"cuda_version_lower_bound": ["13.0", "12.0"]},
+        "x86_64": {"level": ["v4", "v3", "v2"]},
+    }
+
+    # Each variant label maps to its properties, with only the best
+    # compatible value kept for every feature.
+    variant_wheels = {
+        "gpu": [("nvidia", "cuda_version_lower_bound", "13.0")],
+        "gpu_v2": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                   ("x86_64", "level", "v2")],
+        "gpu_v4": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                   ("x86_64", "level", "v4")],
+        "cpu_v4": [("x86_64", "level", "v4")],
+    }
+
+    def rank(prop):
+        """Rank a triple. The ranking lists put the best first, so negate
+        the positions to make a bigger rank mean a better property."""
+        namespace, feature, value = prop
+        return (-namespaces.index(namespace),
+                -features[namespace].index(feature),
+                -values[namespace][feature].index(value))
+
+    def sort_key(label):
+        """Rank a wheel: its property ranks, best first."""
+        return sorted(map(rank, variant_wheels[label]), reverse=True)
+
+    sorted(variant_wheels, key=sort_key, reverse=True)
+    # ['gpu_v4', 'gpu_v2', 'gpu', 'cpu_v4']
+
+The ``gpu*`` wheels sort ahead of ``cpu_v4`` because their best triple
+is in the higher-ranked ``nvidia`` namespace. ``gpu_v4`` beats
+``gpu_v2`` on their second triple, since ``v4`` outranks ``v2``. Both
+beat ``gpu``, whose triples run out first, as the wheel with more
+properties wins.
 
 The ordering for non-variant wheels remains unchanged.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -472,36 +472,56 @@ This specification defines an ordering between different wheels based on
 the presence of variant metadata. It is applied to a list of wheels to
 order them from the most preferable to the least preferable.
 
-The goal of the process is to order the candidate wheels for a given
-project version, so that the most preferable variant is installed.
-Variant wheels MUST be preferred over non-variant wheels, and among them
-wheels featuring more desirable properties MUST be preferred over these
-not featuring them. If multiple variant wheels feature the same
-properties, they MUST be subsequently ordered lexicographically by their
-label as a tie-breaker. If multiple candidate variant wheels with the
-same label or non-variant wheels are present, the ultimate ordering step
-MUST be based on their platform compatibility tags and build numbers.
+The ordering of wheels by platform compatibility tags is not currently
+defined by the specification, beyond a guideline that more specific
+wheels should be preferred. This has not been a big problem, as usually
+there is only one wheel that is compatible with the system, and where
+there are more, the ordering is either clear or insignificant.
 
-The desirability of variant properties is determined from the
-combination of `variant metadata`_ and compatibility information
-obtained for the system, with the process of obtaining it being defined
-in a subsequent PEP. The ``default-priorities.namespace`` key MUST be
-used to order variant namespaces from the most preferable to the least
-preferable, and the compatibility information provides the ordering for
-variant features within the namespaces, and for feature values within
-these features.
+With wheel variants, there can be several compatible wheels per project.
+We define a total ordering to give package authors and users control
+over wheel preference and to ensure that all tools pick the same wheel
+without ambiguity.
 
-For each feature found in variant wheel's properties, only the most
-preferable among its values MUST be counted. The rank of these
-properties MUST then be used to determine the rank of the variant wheel.
-The variant wheel having the most desirable property of all MUST be
-preferred over one not having said property. If multiple wheels have
-that property, then the next most desirable property MUST be used to
-rank them, and so on, until all properties are exhausted.
+Intuitively, we want to choose the wheel that has the best platform
+support property, with tie breaker fallbacks to remove ambiguity. To do
+so, we define a three-level hierarchical ordering between properties. We
+first order by the highest-ranked namespace. If that doesn't suffice, we
+order inside the namespace by its highest-ranked feature, and then
+inside the feature by its highest-ranked value. We then compare
+wheels by their best property. If one wheel's best property is better
+than the best property of another wheel, it wins. As a tie-breaker, for
+two wheels that both have the same highest-ranked
+namespace-feature-value property tuple in the set, we look at
+lower-ranked tuples too.
+
+The ranking for namespaces comes from the package's variant metadata.
+The method for obtaining the ranking for their features and feature
+values will be defined in a subsequent PEP. User overrides are possible
+through tool-specific configuration.
+
+The ordering for non-variant is unchanged. Hence, if there are no
+candidate variant wheels, the behavior remains the same as prior to this
+specification.
+
+A complete algorithm sorting all wheels of a release is provided in the
+subsequent section.
+
+As an example, if there is a GPU-enabled wheel with ``nvidia`` namespace
+properties, and an optimized CPU wheel with ``x86_64`` namespace
+properties, and the package defined that the ``nvidia`` namespace is
+preferable over the ``x86_64`` namespace, the GPU wheel wins. If there
+are two wheels, one with ``nvidia :: cuda_version_lower_bound :: 13.0``
+and another with ``nvidia :: cuda_version_lower_bound :: 12.0``, and the
+ordering defines that ``13.0`` is preferred over ``12.0``, the
+respective wheel wins. If two wheels have the same CUDA properties, but
+one has ``x86_64 :: level :: v4`` property while the other has
+``x86_64 :: level :: v2`` property, and ``v4`` is preferred over ``v2``,
+the former wheel wins.
 
 
-The algorithm
-'''''''''''''
+Ordering algorithm
+''''''''''''''''''
 
 For the purpose of ordering, the combined variant metadata for all
 candidate variant wheels MUST be obtained. It can be sourced either from

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1674,6 +1674,13 @@ Change History
     The investigation in the appendix settles the question in favour of
     markers, so the Open Issues section has been removed and the
     reasoning recorded in the Rationale instead.
+  - Removed grouping by build numbers, instead relegating them to
+    tie-breaking along with other wheel properties. This reverts a
+    potential change in behavior for non-variant wheels.
+  - Added a high-level overview to `variant ordering and selection`_,
+    clarified that the ordering of the lists used in the algorithm is
+    from the most preferable to the least preferable and that the
+    ordering by platform compatibility tags is not changed.
 
 - 19-Aug-2026
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -486,8 +486,8 @@ ordering.
 Every variant property is a ``namespace :: feature :: value`` triple
 whose components are ranked in that order: by namespace first, then by
 feature within the namespace, then by value within the feature. Only
-properties compatible with the target system take part, and only the best
-value within each feature. The ranking for namespaces comes from the
+properties compatible with the target system take part, and only the highest
+ranking compatible value for each feature. The ranking for namespaces comes from the
 package's variant metadata. The ranking for their features and the ranking
 of values within features will be defined in a subsequent PEP.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -478,33 +478,33 @@ wheels should be preferred. This has not been a big problem, as usually
 there is only one wheel that is compatible with the system, and where
 there are more, the ordering is either clear or insignificant.
 
-With wheel variants, there can be several compatible wheels per project.
-We define a total ordering to give package authors and users control
-over wheel preference and to ensure that all tools pick the same wheel
-without ambiguity.
+With wheel variants, there can be several compatible wheels per project
+version. We define a total ordering to give package authors and users
+control over wheel preference and to ensure that all tools select the
+same variant without ambiguity.
 
 Intuitively, we want to choose the wheel that has the best platform
-support property, with tie breaker fallbacks to remove ambiguity. To do
+support property, with tie-breaker fallbacks to remove ambiguity. To do
 so, we define a three-level hierarchical ordering between properties. We
 first order by the highest-ranked namespace. If that doesn't suffice, we
 order inside the namespace by its highest-ranked feature, and then
-inside the feature by its highest-ranked value. We then compare
-wheels by their best property. If one wheel's best property is better
-than the best property of another wheel, it wins. As a tie-breaker, for
-two wheels that both have the same highest-ranked
-namespace-feature-value property tuple in the set, we look at
-lower-ranked tuples too.
+inside the feature by its highest-ranked value, of which only the best
+supported one is retained per feature. We then compare wheels by their
+best property. If one wheel's best property is better than the best
+property of another wheel, it wins. As a tie-breaker, for two wheels
+that both have the same highest-ranked namespace-feature-value property
+tuple, we look at lower-ranked tuples too.
 
 The ranking for namespaces comes from the package's variant metadata.
 The method for obtaining the ranking for their features and feature
-values will be defined in a subsequent PEP. User overrides are possible
-through tool-specific configuration.
+values will be defined in a subsequent PEP. Tools may allow users to
+override this ordering.
 
-The ordering for non-variant is unchanged. Hence, if there are no
+The ordering for non-variant wheels is unchanged. Hence, if there are no
 candidate variant wheels, the behavior remains the same as prior to this
 specification.
 
-A complete algorithm sorting all wheels of a release is provided in the
+The algorithm sorting all wheels of a release is provided in the
 subsequent section.
 
 As an example, if there is a GPU-enabled wheel with ``nvidia`` namespace
@@ -514,7 +514,7 @@ preferable over the ``x86_64`` namespace, the GPU wheel wins. If there
 are two wheels, one with ``nvidia :: cuda_version_lower_bound :: 13.0``
 and another with ``nvidia :: cuda_version_lower_bound :: 12.0``, and the
 ordering defines that ``13.0`` is preferred over ``12.0``, the
-respective wheel wins. If two wheels have the same CUDA properties, but
+former wheel wins. If two wheels have the same CUDA properties, but
 one has ``x86_64 :: level :: v4`` property while the other has
 ``x86_64 :: level :: v2`` property, and ``v4`` is preferred over ``v2``,
 the former wheel wins.
@@ -593,12 +593,11 @@ The algorithm sorts the group of null variant wheels last, as they
 feature no variant properties. The group of non-variant wheels MUST be
 placed after all the other groups.
 
-Within every group, if multiple wheels are compatible, they MUST then be
-ordered according to their remaining properties, such as platform
-compatibility tags and build numbers. This specification does not alter
-this ordering, it remains the same as before. After completing this
-process, the wheels are sorted from the most preferred to the least
-preferred.
+Within every group, the wheels MUST then be ordered according to their
+remaining properties, such as platform compatibility tags and build
+numbers. This specification does not alter this ordering; it remains the
+same as before. After completing this process, the wheels are sorted
+from the most preferred to the least preferred.
 
 The tools MAY provide options to override the default ordering, for
 example by specifying a preference for specific namespaces, features
@@ -948,7 +947,7 @@ behavior would be to:
    mechanism for this will be specified in a subsequent PEP.
 8. Filter and order variants based on the lists of compatible
    properties and select the most preferred variant, per `variant
-   ordering and selection`_,. If no variant wheel matched, use the
+   ordering and selection`_. If no variant wheel matched, use the
    non-variant wheels by their rules.
 9. If multiple wheels for a given version share the same variant label,
    order them by Platform compatibility tags and build number, and
@@ -1099,7 +1098,7 @@ When a package manager is requested to install ``torch``, in order:
 
 5. If variant wheels with multiple different labels remain on the list,
    the results are sorted per the algorithm in `variant ordering and
-   selection`_.  The most preferred label is selected.
+   selection`_. The most preferred label is selected.
 
    For example, in this case the ``cuda*`` wheels are ordered by their
    properties, using the lists obtained in step 4. The wheels for CUDA

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -480,36 +480,39 @@ there are more, the ordering is either clear or insignificant.
 With wheel variants, there can be several compatible wheels per project
 version. We define a total ordering to give package authors and users
 control over wheel preference and to ensure that all tools select the
-same variant without ambiguity.
+same variant without ambiguity. Tools may allow users to override this
+ordering.
 
 Every variant property is a ``namespace :: feature :: value`` triple
-whose components are ranked in that order of significance: by namespace
-first, then by feature within the namespace, then by value within the
-feature. Only properties compatible with the target system take part,
-and each feature contributes just its best compatible value.
+whose components are ranked in that order: by namespace first, then by
+feature within the namespace, then by value within the feature. Only
+properties compatible with the target system take part. The ranking for
+namespaces comes from the package's variant metadata. The ranking itself
+for their features and feature values will be defined in a subsequent PEP.
 
-Each wheel is therefore a tuple of such triples, ordered from its
-highest-ranked property downwards, and wheels are compared
-lexicographically over those tuples. This departs from ordinary tuple
-comparison in one place: where one wheel's triples run out first, the
-wheel with *more* triples wins, as it is the more specific of the two.
 
-The ranking for namespaces comes from the package's variant metadata.
-The method for obtaining the ranking for their features and feature
-values will be defined in a subsequent PEP. Tools may allow users to
-override this ordering.
+To compare two wheels by variant preference, compare their best ranked
+variant property triple. The intuition is that this selects the wheel that
+makes the best use of the target hardware. If both have the same best variant
+property, use the next lower ranked property as a tiebreaker, repeatedly
+until an order is established. By comparing all compatible wheels, this
+yields most preferred wheel.
 
-The ordering for non-variant wheels is unchanged. Hence, if there are no
-candidate variant wheels, the behavior remains the same as prior to this
-specification.
+To express it with Python types instead: Each variant wheel has a set of
+3-tuples, its variant properties. Take the wheels compatible with the
+system and filter their property sets to those compatible with the system.
+Then, sort each wheel's set into an (ordered) list, more preferred properties
+sorted higher. Now you can the sort the wheels by comparing their lists. The
+wheel sorted to the top is the most preferred wheel.
 
-As an example, take a GPU wheel with ``nvidia`` properties and an
+As an example, take a GPU wheel with ``cuda`` properties and an
 optimized CPU wheel with ``x86_64`` properties, where the package ranks
-``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
+``cuda`` first: the GPU wheel wins on its first triple. If two wheels
 carry the same CUDA properties, the comparison moves to their next
 triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
 ``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
 
+The ordering for non-variant wheels remains unchanged.
 
 Ordering algorithm
 ''''''''''''''''''

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -256,7 +256,7 @@ Default priorities
 
 The ``default-priorities`` dictionary defines the ordering of
 namespaces which is used in variant ordering. The exact algorithm is
-described in the `Variant ordering`_ section.
+described in the `Variant ordering and selection`_ section.
 
 The following key is REQUIRED:
 
@@ -462,11 +462,46 @@ consistency`_ and set out in full in
 :ref:`pep825-metadata-consistency`.
 
 
-Variant ordering
-----------------
+Variant ordering and selection
+------------------------------
+
+High-level overview
+'''''''''''''''''''
 
 This specification defines an ordering between different wheels based on
-the presence of variant metadata.
+the presence of variant metadata. It is applied to a list of wheels to
+order them from the most preferable to the least preferable.
+
+The goal of the process is to order the candidate wheels for a given
+project version, so that the most preferable variant is installed.
+Variant wheels MUST be preferred over non-variant wheels, and among them
+wheels featuring more desirable properties MUST be preferred over these
+not featuring them. If multiple variant wheels feature the same
+properties, they MUST be subsequently ordered lexicographically by their
+label as a tie-breaker. If multiple candidate variant wheels with the
+same label or non-variant wheels are present, the ultimate ordering step
+MUST be based on their platform compatibility tags and build numbers.
+
+The desirability of variant properties is determined from the
+combination of `variant metadata`_ and compatibility information
+obtained for the system, with the process of obtaining it being defined
+in a subsequent PEP. The ``default-priorities.namespace`` key MUST be
+used to order variant namespaces from the most preferable to the least
+preferable, and the compatibility information provides the ordering for
+variant features within the namespaces, and for feature values within
+these features.
+
+For each feature found in variant wheel's properties, only the most
+preferable among its values MUST be counted. The rank of these
+properties MUST then be used to determine the rank of the variant wheel.
+The variant wheel having the most desirable property of all MUST be
+preferred over one not having said property. If multiple wheels have
+that property, then the next most desirable property MUST be used to
+rank them, and so on, until all properties are exhausted.
+
+
+The algorithm
+'''''''''''''
 
 For the purpose of ordering, the combined variant metadata for all
 candidate variant wheels MUST be obtained. It can be sourced either from
@@ -481,28 +516,30 @@ features, and features into namespaces. For every namespace, the tool
 MUST obtain a list of compatible features, and for every feature, a list
 of compatible values. The method of obtaining these lists will be
 defined in a subsequent PEP. The items in these lists will be provided
-in specific order that will impact variant wheel ordering.
+ordered from the most preferable to the least preferable.
 
 The compatible wheels corresponding to a particular combination of
-package name, version and build number MUST be grouped by their variant
-label, and a separate group of non-variant wheels MUST be formed. The
-groups of variant wheels MUST then be ordered according to the following
+package name and version MUST be grouped by their variant label, and a
+separate group of non-variant wheels MUST be formed. The groups of
+variant wheels MUST then be ordered according to the following
 algorithm:
 
 1. Construct the ordered list of namespaces by copying the value of the
    ``default-priorities.namespace`` key from the combined variant
    metadata. This is ``namespace_order`` in the example.
 
-2. For every namespace, take the ordered list of compatible feature
-   names obtained previously. This is ``feature_order`` in the example.
+2. For every namespace, take the list of compatible feature names
+   obtained previously, ordered from the most preferable to the least
+   preferable. This is ``feature_order`` in the example.
 
-3. For every feature, take the ordered list of compatible values
-   obtained previously. This is ``value_order`` in the example.
+3. For every feature, take the list of compatible values obtained
+   previously, ordered from the most preferable to the least preferable.
+   This is ``value_order`` in the example.
 
 4. For every group, determine the most preferred value corresponding to
    every variant feature present in the variant properties corresponding
    to the group. This is done by finding among the values the one that
-   has the lowest position in the ordered property value list. After
+   has the lowest index in the ordered property value list. After
    this step, a list of features along with their best values is
    available for every variant. This is done in the
    ``VariantWheel.best_value_properties()`` method in the example.
@@ -514,7 +551,9 @@ algorithm:
    function in the example.
 
 6. For every group, sort the list constructed in step 4 using the sort
-   keys constructed in step 5, in ascending order. This is done by the
+   keys constructed in step 5, in ascending order. The resulting list
+   will be ordered from the most preferable feature to the least
+   preferable feature. This is done by the
    ``VariantWheel.sorted_properties()`` method in the example.
 
 7. To order groups, compare their sorted lists from step 6. If the
@@ -524,17 +563,20 @@ algorithm:
    found or the list in one of the groups is exhausted. In the latter
    case, the group with more keys is sorted earlier. As a fallback,
    if both groups have the same number of keys, they are ordered
-   lexically by the variant label, ascending. This is done by the
-   ultimate step of the example algorithm, with the comparison function
-   being implemented as ``VariantWheel.__lt__()``.
+   lexically by the variant label, ascending. The resulting list of
+   groups will be sorted from the most preferable to the least
+   preferable. This is done by the ultimate step of the example
+   algorithm, with the comparison function being implemented as
+   ``VariantWheel.__lt__()``.
 
 The algorithm sorts the group of null variant wheels last, as they
 feature no variant properties. The group of non-variant wheels MUST be
 placed after all the other groups.
 
 Within every group, the wheels MUST then be ordered according to their
-platform compatibility tags. After this process, the variant wheels are
-sorted from the most preferred to the least preferred.
+platform compatibility tags and build numbers. After this process, the
+variant wheels are sorted from the most preferred to the least
+preferred.
 
 The tools MAY provide options to override the default ordering, for
 example by specifying a preference for specific namespaces, features
@@ -696,7 +738,7 @@ The variant markers MUST only be used in dependency specifiers and MUST
 NOT take part in selecting a wheel. These markers gate the individual
 dependency specifiers of a wheel that has already been selected. They
 MUST be evaluated only once variant wheel selection, as described in
-`variant ordering`_, has taken place.
+`variant ordering and selection`_, has taken place.
 
 Their values MUST be determined as follows:
 
@@ -883,9 +925,9 @@ behavior would be to:
 7. Obtain the ordered lists of compatible variant properties. The
    mechanism for this will be specified in a subsequent PEP.
 8. Filter and order variants based on the lists of compatible
-   properties, per `variant ordering`_, and select the most preferred
-   variant. If no variant wheel matched, use the non-variant wheels by
-   their rules.
+   properties and select the most preferred variant, per `variant
+   ordering and selection`_,. If no variant wheel matched, use the
+   non-variant wheels by their rules.
 9. If multiple wheels for a given version share the same variant label,
    order them by Platform compatibility tags and build number, and
    select the best wheel.
@@ -1034,8 +1076,8 @@ When a package manager is requested to install ``torch``, in order:
    the list.
 
 5. If variant wheels with multiple different labels remain on the list,
-   the results are sorted per the algorithm in `variant ordering`_.
-   The most preferred label is selected.
+   the results are sorted per the algorithm in `variant ordering and
+   selection`_.  The most preferred label is selected.
 
    For example, in this case the ``cuda*`` wheels are ordered by their
    properties, using the lists obtained in step 4. The wheels for CUDA
@@ -1103,9 +1145,9 @@ sources.
 
 A tool that searches sources in priority order (for example, the "index
 priority" in :pep:`766`) can order variants from one source at a time
-using the `variant ordering`_ algorithm, and proceed to the next source
-only if the current one has no viable candidates. No cross-source
-metadata merge is necessary.
+using the `variant ordering and selection`_ algorithm, and proceed to
+the next source only if the current one has no viable candidates. No
+cross-source metadata merge is necessary.
 
 A tool that collates candidates from all sources before selecting among
 them (for example, "version priority" in :pep:`766`) must compare wheels
@@ -1319,7 +1361,7 @@ only ``120_real``, much as a dependency that supports a single CPU
 architecture is gated on ``platform_machine``. Where a dependency does
 exist for every value of a feature, it can instead be published as a
 variant package and depended upon unconditionally, leaving the choice to
-`variant ordering`_.
+`variant ordering and selection`_.
 
 Because of this filtering, the variant markers do not depart from the
 established meaning of an environment marker. Every property in
@@ -1342,10 +1384,10 @@ Three consequences of this design are worth noting:
   for every feature it declares (see `variant properties`_).
   ``variant_features`` and ``variant_namespaces`` therefore always list
   every feature and namespace the wheel was built for. This is why the
-  overrides permitted in `variant ordering`_ may not reach past the
-  compatibility filter: a wheel selected in spite of being unsupported
-  could have its properties filtered away, and the dependencies gated on
-  them would silently disappear.
+  overrides permitted in `variant ordering and selection`_ may not reach
+  past the compatibility filter: a wheel selected in spite of being
+  unsupported could have its properties filtered away, and the
+  dependencies gated on them would silently disappear.
 
 - For the null variant, ``variant_label`` is ``"null"`` and the three
   set-valued markers are empty sets, as the null variant has zero

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -495,7 +495,7 @@ To compare two wheels by variant preference, compare their best-ranked
 variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower-ranked property as a tiebreaker, repeatedly
-until an order is established. All else being equal, the wheel with more
+until an ordering is established. All else being equal, the wheel with more
 properties wins. By comparing all compatible wheels, this yields most
 preferred wheel. This is similar to list and tuple ordering in Python, which
 starts by comparing the first element, then the second, and so forth until

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -487,9 +487,9 @@ Every variant property is a ``namespace :: feature :: value`` triple
 whose components are ranked in that order: by namespace first, then by
 feature within the namespace, then by value within the feature. Only
 properties compatible with the target system take part, and only the highest
-ranking compatible value for each feature. The ranking for namespaces comes from the
-package's variant metadata. The ranking for their features and the ranking
-of values within features will be defined in a subsequent PEP.
+ranking compatible value for each feature. The ranking for namespaces comes
+from the package's variant metadata. The ranking for their features and the
+ranking of values within features will be defined in a subsequent PEP.
 
 To compare two wheels by variant preference, compare their best-ranked
 variant property triple. The intuition is that this selects the wheel that

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -468,9 +468,8 @@ Variant ordering and selection
 High-level overview
 '''''''''''''''''''
 
-This specification defines an ordering between different wheels based on
-the presence of variant metadata. It is applied to a list of wheels to
-order them from the most preferable to the least preferable.
+This specification defines an ordering of wheels based on their variant
+metadata, from the most preferable to the least preferable.
 
 The ordering of wheels by platform compatibility tags is not currently
 defined by the specification, beyond a guideline that more specific
@@ -483,21 +482,17 @@ version. We define a total ordering to give package authors and users
 control over wheel preference and to ensure that all tools select the
 same variant without ambiguity.
 
-Intuitively, we want to choose the wheel with the best platform support,
-with tie-breakers to remove ambiguity. Every variant property is a
-``namespace :: feature :: value`` triple whose components are ranked in
-that order of significance: by namespace first, then by feature within
-the namespace, then by value within the feature. Only properties
-compatible with the target system take part, and each feature
-contributes just its best compatible value.
+Every variant property is a ``namespace :: feature :: value`` triple
+whose components are ranked in that order of significance: by namespace
+first, then by feature within the namespace, then by value within the
+feature. Only properties compatible with the target system take part,
+and each feature contributes just its best compatible value.
 
 Each wheel is therefore a tuple of such triples, ordered from its
 highest-ranked property downwards, and wheels are compared
 lexicographically over those tuples. This departs from ordinary tuple
 comparison in one place: where one wheel's triples run out first, the
 wheel with *more* triples wins, as it is the more specific of the two.
-That is also what sorts the null variant, which has none, last. Wheels
-whose tuples are equal throughout are ordered by variant label.
 
 The ranking for namespaces comes from the package's variant metadata.
 The method for obtaining the ranking for their features and feature
@@ -508,20 +503,12 @@ The ordering for non-variant wheels is unchanged. Hence, if there are no
 candidate variant wheels, the behavior remains the same as prior to this
 specification.
 
-The algorithm sorting all wheels of a release is provided in the
-subsequent section.
-
-As an example, if there is a GPU-enabled wheel with ``nvidia`` namespace
-properties, and an optimized CPU wheel with ``x86_64`` namespace
-properties, and the package defined that the ``nvidia`` namespace is
-preferable over the ``x86_64`` namespace, the GPU wheel wins. If there
-are two wheels, one with ``nvidia :: cuda_version_lower_bound :: 13.0``
-and another with ``nvidia :: cuda_version_lower_bound :: 12.0``, and the
-ordering defines that ``13.0`` is preferred over ``12.0``, the
-former wheel wins. If two wheels have the same CUDA properties, but
-one has ``x86_64 :: level :: v4`` property while the other has
-``x86_64 :: level :: v2`` property, and ``v4`` is preferred over ``v2``,
-the former wheel wins.
+As an example, take a GPU wheel with ``nvidia`` properties and an
+optimized CPU wheel with ``x86_64`` properties, where the package ranks
+``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
+carry the same CUDA properties, the comparison moves to their next
+triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
+``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
 
 
 Ordering algorithm
@@ -552,13 +539,11 @@ algorithm:
    ``default-priorities.namespace`` key from the combined variant
    metadata. This is ``namespace_order`` in the example.
 
-2. For every namespace, take the list of compatible feature names
-   obtained previously, ordered from the most preferable to the least
-   preferable. This is ``feature_order`` in the example.
+2. For every namespace, take the ordered list of compatible feature
+   names obtained previously. This is ``feature_order`` in the example.
 
-3. For every feature, take the list of compatible values obtained
-   previously, ordered from the most preferable to the least preferable.
-   This is ``value_order`` in the example.
+3. For every feature, take the ordered list of compatible values
+   obtained previously. This is ``value_order`` in the example.
 
 4. For every group, determine the most preferred value corresponding to
    every variant feature present in the variant properties corresponding

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -496,7 +496,7 @@ variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower-ranked property as a tiebreaker, repeatedly
 until an ordering is established. All else being equal, the wheel with more
-properties wins. By comparing all compatible wheels, this yields most
+properties wins. By comparing all compatible wheels, this yields the most
 preferred wheel. This is similar to how Python orders lists and tuples:
 it compares corresponding elements from first to last until it finds an
 unequal pair or one sequence runs out of elements.
@@ -511,14 +511,15 @@ order semantics, except for using a sort key that use variant property
 ordering over lexicographic ordering for the tuples inside the list. The
 wheel sorted to the top is the most preferred wheel.
 
-As an example, take a GPU wheel with ``cuda`` properties and an
+As an example, take a GPU wheel with ``nvidia`` properties and an
 optimized CPU wheel with ``x86_64`` properties, where the package ranks
-``cuda`` first: the GPU wheel wins on its first triple. If two wheels
+``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
 carry the same CUDA properties, the comparison moves to their next
 triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
 ``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
 
 The ordering for non-variant wheels remains unchanged.
+
 
 Ordering algorithm
 ''''''''''''''''''

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -520,11 +520,11 @@ As an example, take four variant wheels of a package that ranks the
     # compatible value kept for every feature.
     variant_wheels = {
         "gpu": [("nvidia", "cuda_version_lower_bound", "13.0")],
-        "gpu_v2": [("nvidia", "cuda_version_lower_bound", "13.0"),
-                   ("x86_64", "level", "v2")],
-        "gpu_v4": [("nvidia", "cuda_version_lower_bound", "13.0"),
-                   ("x86_64", "level", "v4")],
-        "cpu_v4": [("x86_64", "level", "v4")],
+        "gpu_cpuv2": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                      ("x86_64", "level", "v2")],
+        "gpu_cpuv4": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                      ("x86_64", "level", "v4")],
+        "cpuv4": [("x86_64", "level", "v4")],
     }
 
     def rank(prop):
@@ -540,11 +540,11 @@ As an example, take four variant wheels of a package that ranks the
         return sorted(map(rank, variant_wheels[label]), reverse=True)
 
     sorted(variant_wheels, key=sort_key, reverse=True)
-    # ['gpu_v4', 'gpu_v2', 'gpu', 'cpu_v4']
+    # ['gpu_cpuv4', 'gpu_cpuv2', 'gpu', 'cpuv4']
 
-The ``gpu*`` wheels sort ahead of ``cpu_v4`` because their best triple
-is in the higher-ranked ``nvidia`` namespace. ``gpu_v4`` beats
-``gpu_v2`` on their second triple, since ``v4`` outranks ``v2``. Both
+The ``gpu*`` wheels sort ahead of ``cpuv4`` because their best triple
+is in the higher-ranked ``nvidia`` namespace. ``gpu_cpuv4`` beats
+``gpu_cpuv2`` on their second triple, since ``v4`` outranks ``v2``. Both
 beat ``gpu``, whose triples run out first, as the wheel with more
 properties wins.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -491,15 +491,15 @@ ranking compatible value for each feature. The ranking for namespaces comes
 from the package's variant metadata. The ranking for their features and the
 ranking of values within features will be defined in a subsequent PEP.
 
-To compare two wheels by variant preference, compare their best-ranked
-variant property triple. The intuition is that this selects the wheel that
-makes the best use of the target hardware. If both have the same best variant
-property, use the next lower-ranked property as a tiebreaker, repeatedly
-until an ordering is established. All else being equal, the wheel with more
-properties wins. By comparing all compatible wheels, this yields the most
-preferred wheel. This is similar to how Python orders lists and tuples:
-it compares corresponding elements from first to last until it finds an
-unequal pair or one sequence runs out of elements.
+Variant wheels sort as Python sorts lists of tuples, each wheel being
+the list of its property triples ordered best first. Where one wheel's
+triples run out, the longer list therefore wins. The intuition is that
+this selects the wheel that makes the best use of the target hardware.
+
+Spelled out: compare two wheels by their best-ranked property triple; if
+those are equal, use the next lower-ranked property as a tiebreaker,
+repeatedly until an ordering is established. Comparing all compatible
+wheels this way yields the most preferred wheel.
 
 As an example, take four variant wheels of a package that ranks the
 ``nvidia`` namespace above ``x86_64``:

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -496,14 +496,14 @@ variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower ranked property as a tiebreaker, repeatedly
 until an order is established. By comparing all compatible wheels, this
-yields most preferred wheel.
+yields most prefered wheel.
 
 To express it with Python types instead: Each variant wheel has a set of
 3-tuples, its variant properties. Take the wheels compatible with the
 system and filter their property sets to those compatible with the system.
-Then, sort each wheel's set into an (ordered) list, more preferred properties
+Then, sort each wheel's set into an (ordered) list, more prefered properties
 sorted higher. Now you can the sort the wheels by comparing their lists. The
-wheel sorted to the top is the most preferred wheel.
+wheel sorted to the top is the most prefered wheel.
 
 As an example, take a GPU wheel with ``cuda`` properties and an
 optimized CPU wheel with ``x86_64`` properties, where the package ranks

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -487,21 +487,24 @@ Every variant property is a ``namespace :: feature :: value`` triple
 whose components are ranked in that order: by namespace first, then by
 feature within the namespace, then by value within the feature. Only
 properties compatible with the target system take part. The ranking for
-namespaces comes from the package's variant metadata. The ranking itself
-for their features and feature values will be defined in a subsequent PEP.
+namespaces comes from the package's variant metadata. The ranking for their
+features and the ranking of values within features will be defined in a
+subsequent PEP.
 
-To compare two wheels by variant preference, compare their best ranked
+To compare two wheels by variant preference, compare their best-ranked
 variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
-property, use the next lower ranked property as a tiebreaker, repeatedly
+property, use the next lower-ranked property as a tiebreaker, repeatedly
 until an order is established. By comparing all compatible wheels, this
 yields most preferred wheel.
 
 To express it with Python types instead: Each variant wheel has a set of
-3-tuples, its variant properties. Take the wheels compatible with the
-system and filter their property sets to those compatible with the system.
-Then, sort each wheel's set into an (ordered) list, more preferred properties
-sorted higher. Now you can the sort the wheels by comparing their lists. The
+3-tuples, its variant properties. Take the compatible wheels and filter
+their property sets to those compatible with the system. Sort the remaining
+set entries into an (ordered) list, more preferred properties sorted higher.
+Now you can the sort the wheels by comparing their lists with Python list
+order semantics, except for using a sort key that use variant property
+ordering over lexicographic ordering for the tuples inside the list. The
 wheel sorted to the top is the most preferred wheel.
 
 As an example, take a GPU wheel with ``cuda`` properties and an

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -483,17 +483,21 @@ version. We define a total ordering to give package authors and users
 control over wheel preference and to ensure that all tools select the
 same variant without ambiguity.
 
-Intuitively, we want to choose the wheel that has the best platform
-support property, with tie-breaker fallbacks to remove ambiguity. To do
-so, we define a three-level hierarchical ordering between properties. We
-first order by the highest-ranked namespace. If that doesn't suffice, we
-order inside the namespace by its highest-ranked feature, and then
-inside the feature by its highest-ranked value, of which only the best
-supported one is retained per feature. We then compare wheels by their
-best property. If one wheel's best property is better than the best
-property of another wheel, it wins. As a tie-breaker, for two wheels
-that both have the same highest-ranked namespace-feature-value property
-tuple, we look at lower-ranked tuples too.
+Intuitively, we want to choose the wheel with the best platform support,
+with tie-breakers to remove ambiguity. Every variant property is a
+``namespace :: feature :: value`` triple whose components are ranked in
+that order of significance: by namespace first, then by feature within
+the namespace, then by value within the feature. Only properties
+compatible with the target system take part, and each feature
+contributes just its best compatible value.
+
+Each wheel is therefore a tuple of such triples, ordered from its
+highest-ranked property downwards, and wheels are compared
+lexicographically over those tuples. This departs from ordinary tuple
+comparison in one place: where one wheel's triples run out first, the
+wheel with *more* triples wins, as it is the more specific of the two.
+That is also what sorts the null variant, which has none, last. Wheels
+whose tuples are equal throughout are ordered by variant label.
 
 The ranking for namespaces comes from the package's variant metadata.
 The method for obtaining the ranking for their features and feature

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -593,9 +593,11 @@ The algorithm sorts the group of null variant wheels last, as they
 feature no variant properties. The group of non-variant wheels MUST be
 placed after all the other groups.
 
-Within every group, the wheels MUST then be ordered according to their
-platform compatibility tags and build numbers. After this process, the
-variant wheels are sorted from the most preferred to the least
+Within every group, if multiple wheels are compatible, they MUST then be
+ordered according to their remaining properties, such as platform
+compatibility tags and build numbers. This specification does not alter
+this ordering, it remains the same as before. After completing this
+process, the wheels are sorted from the most preferred to the least
 preferred.
 
 The tools MAY provide options to override the default ordering, for

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -1328,12 +1328,12 @@ and a publisher of variant wheels may still take that route.
 The requirement is what makes several of the mechanisms defined here
 work at all. If the wheels of one release disagreed about namespace
 order, there would be no total order over the variants, so `variant
-ordering`_ would have no defined output and two conforming installers
-could select different wheels from the same inputs. ``pylock.toml``
-inlines combined variant metadata, so non-deterministic combination
-would mean that two lock runs over one release can produce different
-lock files. And the `index-level metadata`_ file could neither be
-generated from the uploaded wheels alone, nor be relied upon once
+ordering and selection`_ would have no defined output and two conforming
+installers could select different wheels from the same inputs.
+``pylock.toml`` inlines combined variant metadata, so non-deterministic
+combination would mean that two lock runs over one release can produce
+different lock files. And the `index-level metadata`_ file could neither
+be generated from the uploaded wheels alone, nor be relied upon once
 generated, since a resolver would then have to fetch every candidate
 wheel to discover the true combined picture.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -490,20 +490,19 @@ properties compatible with the target system take part. The ranking for
 namespaces comes from the package's variant metadata. The ranking itself
 for their features and feature values will be defined in a subsequent PEP.
 
-
 To compare two wheels by variant preference, compare their best ranked
 variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower ranked property as a tiebreaker, repeatedly
 until an order is established. By comparing all compatible wheels, this
-yields most prefered wheel.
+yields most preferred wheel.
 
 To express it with Python types instead: Each variant wheel has a set of
 3-tuples, its variant properties. Take the wheels compatible with the
 system and filter their property sets to those compatible with the system.
-Then, sort each wheel's set into an (ordered) list, more prefered properties
+Then, sort each wheel's set into an (ordered) list, more preferred properties
 sorted higher. Now you can the sort the wheels by comparing their lists. The
-wheel sorted to the top is the most prefered wheel.
+wheel sorted to the top is the most preferred wheel.
 
 As an example, take a GPU wheel with ``cuda`` properties and an
 optimized CPU wheel with ``x86_64`` properties, where the package ranks

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -486,10 +486,10 @@ ordering.
 Every variant property is a ``namespace :: feature :: value`` triple
 whose components are ranked in that order: by namespace first, then by
 feature within the namespace, then by value within the feature. Only
-properties compatible with the target system take part. The ranking for
-namespaces comes from the package's variant metadata. The ranking for their
-features and the ranking of values within features will be defined in a
-subsequent PEP.
+properties compatible with the target system take part, and only the best
+value within each feature. The ranking for namespaces comes from the
+package's variant metadata. The ranking for their features and the ranking
+of values within features will be defined in a subsequent PEP.
 
 To compare two wheels by variant preference, compare their best-ranked
 variant property triple. The intuition is that this selects the wheel that
@@ -503,8 +503,9 @@ unequal pair or one sequence runs out of elements.
 
 To express it with Python types instead: Each variant wheel has a set of
 3-tuples, its variant properties. Take the compatible wheels and filter
-their property sets to those compatible with the system. Sort the remaining
-set entries into an (ordered) list, more preferred properties sorted higher.
+their property sets to those compatible with the system as well as values
+that are not the best value in their feature. Sort the remaining set entries
+into an (ordered) list, more preferred properties sorted higher.
 Now you can the sort the wheels by comparing their lists with Python list
 order semantics, except for using a sort key that use variant property
 ordering over lexicographic ordering for the tuples inside the list. The

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -497,9 +497,9 @@ makes the best use of the target hardware. If both have the same best variant
 property, use the next lower-ranked property as a tiebreaker, repeatedly
 until an ordering is established. All else being equal, the wheel with more
 properties wins. By comparing all compatible wheels, this yields most
-preferred wheel. This is similar to list and tuple ordering in Python, which
-starts by comparing the first element, then the second, and so forth until
-either one element is unequal or one list has no more elements.
+preferred wheel. This is similar to how Python orders lists and tuples:
+it compares corresponding elements from first to last until it finds an
+unequal pair or one sequence runs out of elements.
 
 To express it with Python types instead: Each variant wheel has a set of
 3-tuples, its variant properties. Take the compatible wheels and filter

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -495,8 +495,11 @@ To compare two wheels by variant preference, compare their best-ranked
 variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower-ranked property as a tiebreaker, repeatedly
-until an order is established. By comparing all compatible wheels, this
-yields most preferred wheel.
+until an order is established. All else being equal, the wheel with more
+properties wins. By comparing all compatible wheels, this yields most
+preferred wheel. This is similar to list and tuple ordering in Python, which
+starts by comparing the first element, then the second, and so forth until
+either one element is unequal or one list has no more elements.
 
 To express it with Python types instead: Each variant wheel has a set of
 3-tuples, its variant properties. Take the compatible wheels and filter


### PR DESCRIPTION
Provide a high-level description of how ordering works and what it is meant to achieve, in addition to the precise algorithm provided right now.  Add clarifications to the algorithm, to make it clear in what order the lists are actually arranged.