### PR TITLE
PEP 825: use a code example to illustrate the ordering in practice

### DIFF
--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -501,22 +501,52 @@ preferred wheel. This is similar to how Python orders lists and tuples:
 it compares corresponding elements from first to last until it finds an
 unequal pair or one sequence runs out of elements.
 
-To express it with Python types instead: Each variant wheel has a set of
-3-tuples, its variant properties. Take the compatible wheels and filter
-their property sets to those compatible with the system as well as values
-that are not the best value in their feature. Sort the remaining set entries
-into an (ordered) list, more preferred properties sorted higher.
-Now you can the sort the wheels by comparing their lists with Python list
-order semantics, except for using a sort key that use variant property
-ordering over lexicographic ordering for the tuples inside the list. The
-wheel sorted to the top is the most preferred wheel.
+As an example, take four variant wheels of a package that ranks the
+``nvidia`` namespace above ``x86_64``:
 
-As an example, take a GPU wheel with ``nvidia`` properties and an
-optimized CPU wheel with ``x86_64`` properties, where the package ranks
-``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
-carry the same CUDA properties, the comparison moves to their next
-triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
-``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
+.. code:: python
+
+    # Rankings, most preferred first. The namespace ranking comes from
+    # the package's variant metadata; the feature and value rankings
+    # will be defined in a subsequent PEP.
+    namespaces = ["nvidia", "x86_64"]
+    features = {"nvidia": ["cuda_version_lower_bound"], "x86_64": ["level"]}
+    values = {
+        "nvidia": {"cuda_version_lower_bound": ["13.0", "12.0"]},
+        "x86_64": {"level": ["v4", "v3", "v2"]},
+    }
+
+    # Each variant label maps to its properties, with only the best
+    # compatible value kept for every feature.
+    variant_wheels = {
+        "gpu": [("nvidia", "cuda_version_lower_bound", "13.0")],
+        "gpu_v2": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                   ("x86_64", "level", "v2")],
+        "gpu_v4": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                   ("x86_64", "level", "v4")],
+        "cpu_v4": [("x86_64", "level", "v4")],
+    }
+
+    def rank(prop):
+        """Rank a triple. The ranking lists put the best first, so negate
+        the positions to make a bigger rank mean a better property."""
+        namespace, feature, value = prop
+        return (-namespaces.index(namespace),
+                -features[namespace].index(feature),
+                -values[namespace][feature].index(value))
+
+    def sort_key(label):
+        """Rank a wheel: its property ranks, best first."""
+        return sorted(map(rank, variant_wheels[label]), reverse=True)
+
+    sorted(variant_wheels, key=sort_key, reverse=True)
+    # ['gpu_v4', 'gpu_v2', 'gpu', 'cpu_v4']
+
+The ``gpu*`` wheels sort ahead of ``cpu_v4`` because their best triple
+is in the higher-ranked ``nvidia`` namespace. ``gpu_v4`` beats
+``gpu_v2`` on their second triple, since ``v4`` outranks ``v2``. Both
+beat ``gpu``, whose triples run out first, as the wheel with more
+properties wins.
 
 The ordering for non-variant wheels remains unchanged.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -496,7 +496,7 @@ variant property triple. The intuition is that this selects the wheel that
 makes the best use of the target hardware. If both have the same best variant
 property, use the next lower-ranked property as a tiebreaker, repeatedly
 until an ordering is established. All else being equal, the wheel with more
-properties wins. By comparing all compatible wheels, this yields most
+properties wins. By comparing all compatible wheels, this yields the most
 preferred wheel. This is similar to how Python orders lists and tuples:
 it compares corresponding elements from first to last until it finds an
 unequal pair or one sequence runs out of elements.
@@ -511,14 +511,15 @@ order semantics, except for using a sort key that use variant property
 ordering over lexicographic ordering for the tuples inside the list. The
 wheel sorted to the top is the most preferred wheel.
 
-As an example, take a GPU wheel with ``cuda`` properties and an
+As an example, take a GPU wheel with ``nvidia`` properties and an
 optimized CPU wheel with ``x86_64`` properties, where the package ranks
-``cuda`` first: the GPU wheel wins on its first triple. If two wheels
+``nvidia`` first: the GPU wheel wins on its first triple. If two wheels
 carry the same CUDA properties, the comparison moves to their next
 triple, and a wheel with ``x86_64 :: level :: v4`` beats one with
 ``x86_64 :: level :: v2``, since ``v4`` outranks ``v2``.
 
 The ordering for non-variant wheels remains unchanged.
+
 
 Ordering algorithm
 ''''''''''''''''''

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -520,11 +520,11 @@ As an example, take four variant wheels of a package that ranks the
     # compatible value kept for every feature.
     variant_wheels = {
         "gpu": [("nvidia", "cuda_version_lower_bound", "13.0")],
-        "gpu_v2": [("nvidia", "cuda_version_lower_bound", "13.0"),
-                   ("x86_64", "level", "v2")],
-        "gpu_v4": [("nvidia", "cuda_version_lower_bound", "13.0"),
-                   ("x86_64", "level", "v4")],
-        "cpu_v4": [("x86_64", "level", "v4")],
+        "gpu_cpuv2": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                      ("x86_64", "level", "v2")],
+        "gpu_cpuv4": [("nvidia", "cuda_version_lower_bound", "13.0"),
+                      ("x86_64", "level", "v4")],
+        "cpuv4": [("x86_64", "level", "v4")],
     }
 
     def rank(prop):
@@ -540,11 +540,11 @@ As an example, take four variant wheels of a package that ranks the
         return sorted(map(rank, variant_wheels[label]), reverse=True)
 
     sorted(variant_wheels, key=sort_key, reverse=True)
-    # ['gpu_v4', 'gpu_v2', 'gpu', 'cpu_v4']
+    # ['gpu_cpuv4', 'gpu_cpuv2', 'gpu', 'cpuv4']
 
-The ``gpu*`` wheels sort ahead of ``cpu_v4`` because their best triple
-is in the higher-ranked ``nvidia`` namespace. ``gpu_v4`` beats
-``gpu_v2`` on their second triple, since ``v4`` outranks ``v2``. Both
+The ``gpu*`` wheels sort ahead of ``cpuv4`` because their best triple
+is in the higher-ranked ``nvidia`` namespace. ``gpu_cpuv4`` beats
+``gpu_cpuv2`` on their second triple, since ``v4`` outranks ``v2``. Both
 beat ``gpu``, whose triples run out first, as the wheel with more
 properties wins.
 

--- a/peps/pep-0825.rst
+++ b/peps/pep-0825.rst
@@ -491,15 +491,15 @@ ranking compatible value for each feature. The ranking for namespaces comes
 from the package's variant metadata. The ranking for their features and the
 ranking of values within features will be defined in a subsequent PEP.
 
-To compare two wheels by variant preference, compare their best-ranked
-variant property triple. The intuition is that this selects the wheel that
-makes the best use of the target hardware. If both have the same best variant
-property, use the next lower-ranked property as a tiebreaker, repeatedly
-until an ordering is established. All else being equal, the wheel with more
-properties wins. By comparing all compatible wheels, this yields the most
-preferred wheel. This is similar to how Python orders lists and tuples:
-it compares corresponding elements from first to last until it finds an
-unequal pair or one sequence runs out of elements.
+Variant wheels sort as Python sorts lists of tuples, each wheel being
+the list of its property triples ordered best first. Where one wheel's
+triples run out, the longer list therefore wins. The intuition is that
+this selects the wheel that makes the best use of the target hardware.
+
+Spelled out: compare two wheels by their best-ranked property triple; if
+those are equal, use the next lower-ranked property as a tiebreaker,
+repeatedly until an ordering is established. Comparing all compatible
+wheels this way yields the most preferred wheel.
 
 As an example, take four variant wheels of a package that ranks the
 ``nvidia`` namespace above ``x86_64``:


### PR DESCRIPTION
Also use the _"it sorts like lists of tuples sort"_ upfront, given that that helps at least a subset of all readers. Remove the textual elaborations of that, just keep the essence and leave the rest to the code example.